### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+
+    # Look for a `go.mod` file in the `root` directory
+    directory: "/"
+
+    # Default is a maximum of five pull requests for version updates
+    open-pull-requests-limit: 10
+
+    target-branch: "master"
+
+    # Daily update checks; default version checks are performed at 05:00 UTC
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+
+    # Assign everything to me by default
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"
+
+    commit-message:
+      # Prefix all commit messages with "go.mod"
+      prefix: "go.mod"
+
+  #####################################################
+  # Re-enable for GH-12
+  #####################################################
+
+  # - package-ecosystem: "github-actions"
+  #   directory: "/"
+  #   open-pull-requests-limit: 10
+  #   target-branch: "master"
+  #   schedule:
+  #     interval: "daily"
+  #     time: "02:00"
+  #     timezone: "America/Chicago"
+  #   assignees:
+  #     - "atc0005"
+  #   labels:
+  #     - "dependencies"
+  #     - "CI"
+  #   allow:
+  #     - dependency-type: "all"
+  #   commit-message:
+  #     prefix: "ghaw"


### PR DESCRIPTION
- Enable Go Modules
- Stub out, but not yet enable GitHub Actions

fixes GH-11