### PR TITLE
Tools | Add flag to toggle eval of powered off VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ TODO: Remove this section and instead duplicate the full table for each plugin.
 | `include-rp`      | No       |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be exclusively used when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to ignore or exclude from evaluation. |
 | `exclude-rp`      | No       |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be ignored when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to include for evaluation.                     |
 | `ignore-vm`       | No       |         | No     | *comma-separated list of (vSphere) virtual machine names*               | Specifies a comma-separated list of VM names that should be ignored or excluded from evaluation.                                                                                                                   |
+| `powered-off`     | No       | `false` | No     | `true`, `false`                                                         | Toggles evaluation of powered off VMs in addition to powered on VMs. Evaluation of powered off VMs is disabled by default.                                                                                         |
 
 ### Configuration file
 

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -68,6 +68,7 @@ func main() {
 		Str("included_resource_pools", cfg.IncludedResourcePools.String()).
 		Str("excluded_resource_pools", cfg.ExcludedResourcePools.String()).
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
+		Bool("eval_powered_off", cfg.PoweredOff).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")
@@ -171,7 +172,7 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Checking VMware Tools state")
-	vmsWithIssues := vsphere.GetVMsWithToolsIssues(filteredVMs)
+	vmsWithIssues := vsphere.GetVMsWithToolsIssues(filteredVMs, cfg.PoweredOff)
 
 	if len(vmsWithIssues) > 0 {
 
@@ -200,6 +201,7 @@ func main() {
 			c,
 			vms,
 			filteredVMs,
+			vmsWithIssues,
 			cfg.IgnoredVMs,
 			cfg.IncludedResourcePools,
 			cfg.ExcludedResourcePools,
@@ -232,6 +234,7 @@ func main() {
 		c,
 		vms,
 		filteredVMs,
+		vmsWithIssues,
 		cfg.IgnoredVMs,
 		cfg.IncludedResourcePools,
 		cfg.ExcludedResourcePools,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,10 @@ type Config struct {
 	// returned.
 	timeout int
 
+	// PoweredOff indicates whether powered off VMs are evaluated in addition
+	// to powered on VMs.
+	PoweredOff bool
+
 	// Whether the certificate should be trusted as-is without validation.
 	TrustCert bool
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -24,6 +24,7 @@ const (
 	includedResourcePoolsFlagHelp string = "Specifies a comma-separated list of Resource Pools that should be exclusively used when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to ignore or exclude from evaluation."
 	excludedResourcePoolsFlagHelp string = "Specifies a comma-separated list of Resource Pools that should be ignored when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to include for evaluation."
 	ignoreVMsFlagHelp             string = "Specifies a comma-separated list of VM names that should be ignored or excluded from evaluation."
+	poweredOffFlagHelp            string = "Toggles evaluation of powered off VMs in addition to powered on VMs. Evaluation of powered off VMs is disabled by default."
 )
 
 // Default flag settings if not overridden by user input
@@ -37,6 +38,7 @@ const (
 	defaultPort                  int    = 443
 	defaultBranding              bool   = false
 	defaultDisplayVersionAndExit bool   = false
+	defaultPoweredOff            bool   = false
 
 	// Default timeout (in seconds) used when connecting to a remote server
 	defaultConnectTimeout int = 10

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -23,6 +23,7 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)
 		flag.Var(&c.ExcludedResourcePools, "exclude-rp", excludedResourcePoolsFlagHelp)
 		flag.Var(&c.IgnoredVMs, "ignore-vm", ignoreVMsFlagHelp)
+		flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 
 	case pluginType.SnapshotsAge:
 


### PR DESCRIPTION
This PR adds support for toggling the evaluation of powered off VMs in addition to powered on VMs. This is disabled by default as the results are likely to cause false-positives when setting up new VMs, booting into rescue environments, etc.

I've also made minor tweaks to summary output in an attempt to make larger lists of VMs easier to read.

refs GH-2