### PR TITLE
Refactor VMs Tools, power state filtering

### DIFF
--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -163,6 +163,9 @@ func main() {
 	log.Debug().Msg("Drop any VMs we've been asked to exclude from checks")
 	filteredVMs := vsphere.ExcludeVMsByName(vms, cfg.IgnoredVMs)
 
+	log.Debug().Msg("Filter VMs to specified power state")
+	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
+
 	vmNames := make([]string, 0, len(filteredVMs))
 	for _, vm := range filteredVMs {
 		vmNames = append(vmNames, vm.Name)
@@ -171,8 +174,8 @@ func main() {
 		Str("virtual_machines", strings.Join(vmNames, ", ")).
 		Msg("")
 
-	log.Debug().Msg("Checking VMware Tools state")
-	vmsWithIssues := vsphere.GetVMsWithToolsIssues(filteredVMs, cfg.PoweredOff)
+	log.Debug().Msg("Filter VMs to those with VMware Tools issues")
+	vmsWithIssues := vsphere.FilterVMsWithToolsIssues(filteredVMs)
 
 	if len(vmsWithIssues) > 0 {
 


### PR DESCRIPTION
- Tools issue filtering is limited to that sole purpose
- New function for filtering VMs based on power state only

This refactoring is work towards implementing a vCPUs plugin which
will also make use of this new power state filtering functionality.

refs GH-2
refs GH-1