### PR TITLE
Update build steps to include current plugins

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -83,3 +83,4 @@ jobs:
       - name: Build using vendored dependencies
         run: |
           go build -v -mod=vendor ./cmd/check_vmware_tools
+          go build -v -mod=vendor ./cmd/check_vmware_vcpus

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 SHELL = /bin/bash
 
 # Space-separated list of cmd/BINARY_NAME directories to build
-WHAT 					= check_vmware_tools
+WHAT 					= check_vmware_tools check_vmware_vcpus
 
 
 # What package holds the "version" variable used in branding/version output?


### PR DESCRIPTION
The vCPUs plugin was missing from:

- Makefile
- GHAW

This commit updates both to include the missing entry.