### PR TITLE
Fix project name

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -7,8 +7,8 @@
 
 package config
 
-const myAppName string = "check-cert"
-const myAppURL string = "https://github.com/atc0005/check-vmware"
+const myAppName string = "check-vmware"
+const myAppURL string = "https://github.com/atc0005/" + myAppName
 
 const (
 	versionFlagHelp                  string = "Whether to display application version and then immediately exit application."


### PR DESCRIPTION
Update constants values to use correct project name. 

Remove duplicate value from project URL constant and reuse app name constant. This is done in case I use *this* project as a template for my next one so that I won't end up changing one value and forgetting to do the same for the other (as I did here in this project).