### PR TITLE
Allow specifying lists of values w or w/o quotes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,8 @@ func (mvs *multiValueStringFlag) Set(value string) error {
 	items := strings.Split(value, ",")
 	for index, item := range items {
 		items[index] = strings.TrimSpace(item)
+		items[index] = strings.ReplaceAll(items[index], "'", "")
+		items[index] = strings.ReplaceAll(items[index], "\"", "")
 	}
 
 	// add them to the collection


### PR DESCRIPTION
This allows existing Nagios service check configurations used by our team to work as-is with quoted items or bare. 

Brief testing confirms the results are as expected.

fixes GH-38