### PR TITLE
Wire-up user domain support

### DIFF
--- a/internal/vsphere/login.go
+++ b/internal/vsphere/login.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/vmware/govmomi"
 )
@@ -39,6 +40,9 @@ func Login(
 		return nil, parseErr
 	}
 
+	if domain != "" {
+		username = strings.Join([]string{username, domain}, "@")
+	}
 	u.User = url.UserPassword(username, password)
 
 	c, authErr := govmomi.NewClient(ctx, u, trustCert)


### PR DESCRIPTION
The login function accepted the user domain value, but previously did not do anything with it. 

This commit attempts to join any provided user domain with the username via email account syntax. Brief testing suggests that this works as expected.