### PR TITLE
Fix typo in project breadcrumb URL

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,6 @@
 # Copyright 2021 Adam Chalkley
 #
-# https:#github.com/atc0005/check-vmware
+# https://github.com/atc0005/check-vmware
 #
 # Licensed under the MIT License. See LICENSE file in the project root for
 # full license information.


### PR DESCRIPTION
Evidently a typo from the original project I based this one off of made its way here.