### PR TITLE
GHAW: Increase timeout for Makefile builds

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -56,7 +56,7 @@ jobs:
     name: Build codebase using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 10
+    timeout-minutes: 20
     container:
       image: "index.docker.io/golang:latest"
 


### PR DESCRIPTION
I've noticed that building all binaries using the Makefile
is starting to average about 7 minutes. Since it won't be
long until we hit the configured 10 minute timeout, this
commit bumps the time out to 20 minutes.

If we approach 20 minutes for a CI run we'll need to
reconsider our options.