### PR TITLE
check_vmware_datastore | Fix DS usage rounding

### DIFF
--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -328,7 +328,7 @@ func DatastoreUsageReport(
 		vmPercentOfDSUsed := float64(vmStorageUsed) / float64(dsUsageSummary.StorageTotal) * 100
 		fmt.Fprintf(
 			tw,
-			"%s\t%v\t%1.f%%%s",
+			"%s\t%v\t%2.2f%%%s",
 			vm.Name,
 			units.ByteSize(vmStorageUsed),
 			vmPercentOfDSUsed,


### PR DESCRIPTION
Allow wider precision in order to better report usage for VMs with a smaller total datastore usage.

fixes GH-62