### PR TITLE
Limit storage calculations to relevant datastore

### DIFF
--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -324,7 +324,14 @@ func DatastoreUsageReport(
 	fmt.Fprintf(tw, "Name\tSpace used\tDatastore Usage%s", nagios.CheckOutputEOL)
 
 	for _, vm := range dsVMs {
-		vmStorageUsed := vm.Summary.Storage.Committed + vm.Summary.Storage.Uncommitted
+
+		var vmStorageUsed int64
+		for _, usage := range vm.Storage.PerDatastoreUsage {
+			if usage.Datastore == dsUsageSummary.Datastore.Reference() {
+				vmStorageUsed += usage.Committed + usage.Uncommitted
+			}
+		}
+
 		vmPercentOfDSUsed := float64(vmStorageUsed) / float64(dsUsageSummary.StorageTotal) * 100
 		fmt.Fprintf(
 			tw,

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -23,6 +23,7 @@ func getVirtualMachinePropsSubset() []string {
 		"resourcePool",
 		"config",
 		"snapshot",
+		"storage",
 		"guest",
 		"name",
 		"network",


### PR DESCRIPTION
Instead of (unintentionally) using the aggregate datastore usage of a VM, filter storage use to just the relevant datastore that we are evaluating. 

fixes GH-61
