### PR TITLE
Remove duplicated ignored_vms logging field

### DIFF
--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -83,7 +83,6 @@ func main() {
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
 		Int("snapshots_age_critical", cfg.SnapshotsAgeCritical).
 		Int("snapshots_age_warning", cfg.SnapshotsAgeWarning).
-		Str("ignored_vms", cfg.IgnoredVMs.String()).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")


### PR DESCRIPTION
Spotted this while working on a new plugin.

fixes GH-77