### PR TITLE
Fix age not yet exceeded snapshots display logic

### DIFF
--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -611,10 +611,7 @@ func SnapshotsAgeReport(
 	)
 
 	switch {
-	case len(snapshotSummarySets) > 0 &&
-		!snapshotSummarySets.IsAgeCriticalState() &&
-		!snapshotSummarySets.IsAgeWarningState():
-
+	case len(snapshotSummarySets) > 0:
 		for _, snapSet := range snapshotSummarySets {
 			for _, snap := range snapSet.Snapshots {
 				if !snap.IsAgeCriticalState() && !snap.IsAgeWarningState() {


### PR DESCRIPTION
Remove state checks at the snapshot summary sets level, rely on individual snapshot state checks to determine inclusion in the "not yet exceeded" list.

The net result is that the snapshots summary report is generated as intended. As noted previously, further refactoring is warranted for a later point in time.

fixes GH-81