### PR TITLE
Fix length check for affected VMs listing

### DIFF
--- a/internal/vsphere/tools.go
+++ b/internal/vsphere/tools.go
@@ -179,7 +179,7 @@ func VMToolsReport(
 
 	switch {
 
-	case len(vmsWithIssues) > 1:
+	case len(vmsWithIssues) > 0:
 
 		sort.Slice(vmsWithIssues, func(i, j int) bool {
 			return strings.ToLower(vmsWithIssues[i].Name) < strings.ToLower(vmsWithIssues[j].Name)


### PR DESCRIPTION
The mistake resulted in a list of 1 being omitted from the Long Service Output report.

fixes GH-88