### PR TITLE
Initial draft of snapshots size monitoring plugin

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -88,3 +88,4 @@ jobs:
           go build -v -mod=vendor ./cmd/check_vmware_hs2ds2vms
           go build -v -mod=vendor ./cmd/check_vmware_datastore
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_age
+          go build -v -mod=vendor ./cmd/check_vmware_snapshots_size

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ scratch/
 /check_vmware_hs2ds2vms
 /check_vmware_datastore
 /check_vmware_snapshots_age
+/check_vmware_snapshots_size

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ WHAT 					= check_vmware_tools \
 							check_vmware_vhw \
 							check_vmware_hs2ds2vms \
 							check_vmware_datastore \
-							check_vmware_snapshots_age
+							check_vmware_snapshots_age \
+							check_vmware_snapshots_size \
 
 
 # What package holds the "version" variable used in branding/version output?

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -35,7 +35,7 @@ func main() {
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
-	cfg, cfgErr := config.New(config.PluginType{SnapshotsAge: true})
+	cfg, cfgErr := config.New(config.PluginType{SnapshotsSize: true})
 	switch {
 	case errors.Is(cfgErr, config.ErrVersionRequested):
 		fmt.Println(config.Version())
@@ -63,13 +63,13 @@ func main() {
 	// content is shown in the detailed web UI and in notifications generated
 	// by Nagios.
 	nagiosExitState.CriticalThreshold = fmt.Sprintf(
-		"%d day old snapshots present",
-		cfg.SnapshotsAgeCritical,
+		"%d GB size snapshots present",
+		cfg.SnapshotsSizeCritical,
 	)
 
 	nagiosExitState.WarningThreshold = fmt.Sprintf(
-		"%d day old snapshots present",
-		cfg.SnapshotsAgeWarning,
+		"%d GB size snapshots present",
+		cfg.SnapshotsSizeWarning,
 	)
 
 	if cfg.EmitBranding {
@@ -81,8 +81,8 @@ func main() {
 		Str("included_resource_pools", cfg.IncludedResourcePools.String()).
 		Str("excluded_resource_pools", cfg.ExcludedResourcePools.String()).
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
-		Int("snapshots_age_critical", cfg.SnapshotsAgeCritical).
-		Int("snapshots_age_warning", cfg.SnapshotsAgeWarning).
+		Int("snapshots_size_critical", cfg.SnapshotsSizeCritical).
+		Int("snapshots_size_warning", cfg.SnapshotsSizeWarning).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")
@@ -230,28 +230,28 @@ func main() {
 
 	switch {
 
-	case snapshotSets.IsAgeCriticalState():
+	case snapshotSets.IsSizeCriticalState():
 
 		log.Error().
-			Int("num_snapshots_age_critical", snapshotSets.ExceedsAge(cfg.SnapshotsAgeCritical)).
-			Msg("Snapshot sets contain a snapshot which exceeds specified age in days")
+			Int("num_snapshots_size_critical", snapshotSets.ExceedsSize(cfg.SnapshotsSizeCritical)).
+			Msg("Snapshot sets contain a snapshot which exceeds specified size in GB")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed
+		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
 
-		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
+		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			filteredVMs,
 			resourcePools,
 		)
 
-		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
+		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -266,28 +266,28 @@ func main() {
 
 		return
 
-	case snapshotSets.IsAgeWarningState():
+	case snapshotSets.IsSizeWarningState():
 
 		log.Error().
-			Int("num_snapshots_age_warning", snapshotSets.ExceedsAge(cfg.SnapshotsAgeWarning)).
-			Msg("Snapshot sets contain one or more snapshots which exceed specified age in days")
+			Int("num_snapshots_size_warning", snapshotSets.ExceedsSize(cfg.SnapshotsSizeWarning)).
+			Msg("Snapshot sets contain one or more snapshots which exceed specified size in GB")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed
+		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
 
-		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
+		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			filteredVMs,
 			resourcePools,
 		)
 
-		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
+		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -306,20 +306,20 @@ func main() {
 
 		nagiosExitState.LastError = nil
 
-		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
+		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			filteredVMs,
 			resourcePools,
 		)
 
-		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
+		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			cfg.SnapshotsSizeCritical,
+			cfg.SnapshotsSizeWarning,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -54,6 +54,8 @@ contrib
         │       ├── send2teams.cfg
         │       ├── vmware-datastores.cfg
         │       ├── vmware-host-datastore-vms-pairings.cfg
+        │       ├── vmware-snapshots-age.cfg
+        │       ├── vmware-snapshots-size.cfg
         │       ├── vmware-tools.cfg
         │       ├── vmware-vcpus.cfg
         │       └── vmware-virtual-hardware.cfg
@@ -83,7 +85,7 @@ contrib
             ├── nagios.cfg
             └── resource.cfg
 
-13 directories, 23 files
+13 directories, 25 files
 ```
 
 ### Overview

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-size.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-size.cfg
@@ -1,0 +1,33 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Look at specific pools, exclude other pools
+define command{
+    command_name    check_vmware_snapshots_size_include_pools
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    }
+
+# Look at specific pools, exclude other pools, exclude list of VMs
+define command{
+    command_name    check_vmware_snapshots_size_include_pools_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    }
+
+# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally.
+define command{
+    command_name    check_vmware_snapshots_size
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --trust-cert --log-level info
+    }
+
+# Look at all pools, exclude list of VMs
+define command{
+    command_name    check_vmware_snapshots_size_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    }

--- a/doc.go
+++ b/doc.go
@@ -29,6 +29,8 @@ hosts or vCenter instances) for select (or all) Resource Pools.
 
 • Snapshots age
 
+• Snapshots size
+
 USAGE
 
 See our main README for supported settings and examples.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,12 +184,12 @@ type Config struct {
 	// usage (as a whole number) when a CRITICAL threshold is reached.
 	DatastoreUsageCritical int
 
-	// SnapshotsSizeWarning specifies the size of a snapshot in GB when a
-	// WARNING threshold is reached. 20 GB is the default.
+	// SnapshotsSizeCritical specifies the cumulative size in GB of all
+	// snapshots for a VM when a WARNING threshold is reached.
 	SnapshotsSizeWarning int
 
-	// SnapshotsSizeCritical specifies the size of a snapshot in GB when a
-	// CRITICAL threshold is reached. 40 GB is the default.
+	// SnapshotsSizeCritical specifies the cumulative size in GB of all
+	// snapshots for a VM when a CRITICAL threshold is reached.
 	SnapshotsSizeCritical int
 
 	// SnapshotsAgeWarning specifies the age of a snapshot in days when a

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -42,10 +42,8 @@ const (
 	datacenterNameFlagHelp                          string = "Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts."
 	snapshotsAgeCriticalFlagHelp                    string = "Specifies the age of a snapshot in days when a CRITICAL threshold is reached."
 	snapshotsAgeWarningFlagHelp                     string = "Specifies the age of a snapshot in days when a WARNING threshold is reached."
-
-	// See atc0005/check-vmware#4,vmware/govmomi#2243
-	// snapshotsSizeCriticalFlagHelp                   string = "Specifies the size of a snapshot in GB when a CRITICAL threshold is reached."
-	// snapshotsSizeWarningFlagHelp                    string = "Specifies the size of a snapshot in GB when a WARNING threshold is reached."
+	snapshotsSizeCriticalFlagHelp                   string = "Specifies the cumulative size in GB of all snapshots for a Virtual Machine when a CRITICAL threshold is reached."
+	snapshotsSizeWarningFlagHelp                    string = "Specifies the cumulative size in GB of all snapshots for a Virtual Machine when a WARNING threshold is reached."
 )
 
 // Default flag settings if not overridden by user input
@@ -69,6 +67,8 @@ const (
 	defaultDatacenterName               string = ""
 	defaultSnapshotsAgeCritical         int    = 2
 	defaultSnapshotsAgeWarning          int    = 1
+	defaultSnapshotsSizeCritical        int    = 40 // size in GB
+	defaultSnapshotsSizeWarning         int    = 20 // size in GB
 
 	// Intentionally set low to trigger validation failure if not specified by
 	// the end user.

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -46,7 +46,6 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.IntVar(&c.SnapshotsAgeCritical, "ac", defaultSnapshotsAgeCritical, snapshotsAgeCriticalFlagHelp)
 		flag.IntVar(&c.SnapshotsAgeCritical, "age-critical", defaultSnapshotsAgeCritical, snapshotsAgeCriticalFlagHelp)
 
-	// See atc0005/check-vmware#4,vmware/govmomi#2243
 	case pluginType.SnapshotsSize:
 
 		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)
@@ -62,11 +61,11 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		//
 		// flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 
-	// 	flag.IntVar(&c.SizeWarning, "sw", defaultSnapshotSizeWarning, snapshotSizeWarningFlagHelp)
-	// 	flag.IntVar(&c.SizeWarning, "size-warning", defaultSnapshotSizeWarning, snapshotSizeWarningFlagHelp)
-	//
-	// 	flag.IntVar(&c.SizeCritical, "sc", defaultSnapshotSizeCritical, snapshotSizeCriticalFlagHelp)
-	// 	flag.IntVar(&c.SizeCritical, "size-critical", defaultSnapshotSizeCritical, snapshotSizeCriticalFlagHelp)
+		flag.IntVar(&c.SnapshotsSizeWarning, "sw", defaultSnapshotsSizeWarning, snapshotsSizeWarningFlagHelp)
+		flag.IntVar(&c.SnapshotsSizeWarning, "size-warning", defaultSnapshotsSizeWarning, snapshotsSizeWarningFlagHelp)
+
+		flag.IntVar(&c.SnapshotsSizeCritical, "sc", defaultSnapshotsSizeCritical, snapshotsSizeCriticalFlagHelp)
+		flag.IntVar(&c.SnapshotsSizeCritical, "size-critical", defaultSnapshotsSizeCritical, snapshotsSizeCriticalFlagHelp)
 
 	case pluginType.DatastoresSize:
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -42,7 +42,39 @@ func (c Config) validate(pluginType PluginType) error {
 			)
 		}
 
+		if c.SnapshotsAgeCritical == c.SnapshotsAgeWarning {
+			return fmt.Errorf(
+				"critical threshold set equal to warning threshold",
+			)
+		}
+
 	case pluginType.SnapshotsSize:
+
+		if c.SnapshotsSizeWarning < 0 {
+			return fmt.Errorf(
+				"invalid snapshot size WARNING threshold number: %d",
+				c.SnapshotsSizeWarning,
+			)
+		}
+
+		if c.SnapshotsSizeCritical < 0 {
+			return fmt.Errorf(
+				"invalid snapshot size CRITICAL threshold number: %d",
+				c.SnapshotsSizeCritical,
+			)
+		}
+
+		if c.SnapshotsSizeCritical < c.SnapshotsSizeWarning {
+			return fmt.Errorf(
+				"critical threshold set lower than warning threshold",
+			)
+		}
+
+		if c.SnapshotsSizeCritical == c.SnapshotsSizeWarning {
+			return fmt.Errorf(
+				"critical threshold set equal to warning threshold",
+			)
+		}
 
 	case pluginType.DatastoresSize:
 

--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -34,3 +34,15 @@ const (
 	MgObjRefTypeResourcePool    string = "ResourcePool"
 	MgObjRefTypeHostSystem      string = "HostSystem"
 )
+
+// used with snapshots reports that provide Long Service Output
+const (
+	snapshotThresholdTypeAge  string = "age"
+	snapshotThresholdTypeSize string = "size"
+)
+
+// used with snapshots reports that provide Long Service Output
+const (
+	snapshotThresholdTypeAgeSuffix  string = "d"
+	snapshotThresholdTypeSizeSuffix string = "GB"
+)


### PR DESCRIPTION
## CREDIT

This plugin would simply not have been possible without the help from
@dougm. I'm grateful for both the general feedback (confirming I was
looking in the right direction) and taking the time to craft code
samples based on a review of the PowerCLI (C#) `Get-Snapshot`
implementation.

The logic used in this plugin is heavily inspired from the ideas
presented, but *attempts* to use a slightly different (but probably
less efficient) approach that made more sense to me. The current
implementation is based on an evolution of my understanding of the
API. While I believe the end results between the two implementations
are the same, with further refactoring the implementation used by this
project will probably end up looking nearly the same as the code
examples originally presented.

## OVERVIEW

As with several other plugins in this project, this one borrows
heavily from existing projects. In particular, this plugin was
initially based on a PowerShell / PowerCLI plugin I wrote in 2019.

In short, this plugin attempts to provide snapshot size details per
snapshot for review, but evaluates size of snapshots for a VM based on
the total of all snapshot size values, not individual values. This
differs from the snapshots age plugin, which checks each snapshot
individually to determine the service check result.

Doc updates have been applied, example usage has been added, including
a command definition "contrib" file illustrating how the plugin would
be referenced within a production Nagios configuration.

Partial work implemented with the snapshots age monitoring plugin to
handle size monitoring has been completed and is functional as of this
set of changes. Further refactoring and polish is needed, but based on
initial use in our production environment the results appear to match
the results provided by PowerCLI `Get-Snapshot` results.

## OTHER CHANGES

- Minor tweaks to snapshots age plugin to better mirror new snapshots
  size plugin. The idea is to eventually refactor both to share
  common code instead of replicating between the two.
- Refactoring (more todo) of `internal/vsphere` code used by both
  plugins

## REFERENCES

- fixes atc0005/check-vmware#4
- refs atc0005/check-vmware#69
- refs vmware/govmomi#2243
