### PR TITLE
Add GoDoc coverage for project plugins

### DIFF
--- a/cmd/check_vmware_datastore/doc.go
+++ b/cmd/check_vmware_datastore/doc.go
@@ -1,0 +1,27 @@
+/*
+
+Nagios plugin used to monitor datastore usage.
+
+PURPOSE
+
+In addition to reporting current datastore usage, this plugin also reports
+which VMs reside on the datastore along with their percentage of the total
+datastore space used.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_hs2ds2vms/doc.go
+++ b/cmd/check_vmware_hs2ds2vms/doc.go
@@ -1,0 +1,34 @@
+/*
+
+Nagios plugin used to monitor host/datastore/vm pairings.
+
+PURPOSE
+
+This is a functional plugin responsible for verifying that each VM is housed
+on a datastore (best) intended for the host associated with the VM.
+
+By default, the evaluation is limited to powered on VMs, but this can be
+toggled to also include powered off VMs.
+
+The association between datastores and hosts is determined by a user-provided
+Custom Attribute. Flags for this plugin allow specifying separate Custom
+Attribute names for hosts and datastores along with optional separate prefixes
+for the provided Custom Attributes.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_snapshots_age/doc.go
+++ b/cmd/check_vmware_snapshots_age/doc.go
@@ -1,0 +1,31 @@
+/*
+
+Nagios plugin used to monitor the age of Virtual Machine snapshots.
+
+PURPOSE
+
+Monitor the age of individual snapshots for each Virtual Machine.
+
+The current design of this plugin is to evaluate *all* Virtual Machines,
+whether powered off or powered on. If you have a use case for evaluating
+*only* powered on VMs by default, please add a comment to
+https://github.com/atc0005/check-vmware/issues/79 providing some details for
+your use-case.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_snapshots_size/doc.go
+++ b/cmd/check_vmware_snapshots_size/doc.go
@@ -1,0 +1,36 @@
+/*
+
+Nagios plugin used to monitor the cumulative size of snapshots for each
+Virtual Machine.
+
+PURPOSE
+
+Monitor the **cumulative** size of snapshots for each Virtual Machine.
+
+While individual snapshots are listed, it is the cumulative size for a Virtual
+Machine crossing a given size threshold that determines the overall check
+result.
+
+The current design of this plugin is to evaluate *all* Virtual Machines,
+whether powered off or powered on. If you have a use case for evaluating
+*only* powered on VMs by default, please add a comment to
+https://github.com/atc0005/check-vmware/issues/79 providing some details for
+your use-case.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_tools/doc.go
+++ b/cmd/check_vmware_tools/doc.go
@@ -1,0 +1,23 @@
+/*
+
+Nagios plugin used to monitor VMware Tools installations.
+
+PURPOSE
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_vcpus/doc.go
+++ b/cmd/check_vmware_vcpus/doc.go
@@ -1,0 +1,23 @@
+/*
+
+Nagios plugin used to monitor allocation of virtual CPUs (vCPUs).
+
+PURPOSE
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/cmd/check_vmware_vhw/doc.go
+++ b/cmd/check_vmware_vhw/doc.go
@@ -1,0 +1,37 @@
+/*
+
+Nagios plugin used to monitor virtual hardware versions.
+
+PURPOSE
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+CAVEATS
+
+As of this writing, I am unaware of a way to query the current vSphere
+environment for the latest available hardware version. As a workaround for
+that lack of knowledge, this plugin applies an automatic baseline of "highest
+version discovered" across evaluated VMs. Any VMs with a hardware version not
+at that highest version are flagged as problematic. Please file an issue or
+open a discussion in this project's repo if you're aware of a way to directly
+query the desired value from the current vSphere environment.
+
+Instead of trying to determine how far behind each VM is from the newest
+version, this plugin assumes that any deviation is a WARNING level issue.
+See GH-33 for future potential changes to this behavior.
+
+*/
+package main

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,7 @@
 /*
 
-This repo contains various tools used to monitor VMware environments.
+Go-based tooling to monitor VMware environments; **NOT** affiliated with
+or endorsed by VMware, Inc.
 
 PROJECT HOME
 


### PR DESCRIPTION
Add new doc.go file to each plugin directory to better summarize the functionality of each plugin when viewing the project documentation at pkg.go.dev.

fixes GH-85