### PR TITLE
Add support to toggle vSphere package log messages

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -34,6 +34,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -56,6 +60,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
@@ -221,9 +230,6 @@ func main() {
 				cfg.SnapshotsAgeWarning,
 				cfg.SnapshotsSizeCritical,
 				cfg.SnapshotsSizeWarning,
-
-				// revisit with GH-76
-				false,
 			),
 		)
 	}

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
@@ -221,9 +230,6 @@ func main() {
 				cfg.SnapshotsAgeWarning,
 				cfg.SnapshotsSizeCritical,
 				cfg.SnapshotsSizeWarning,
-
-				// revisit with GH-76
-				false,
 			),
 		)
 	}

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -32,6 +32,10 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Disable library debug logging output by default
+	// vsphere.EnableLogging()
+	vsphere.DisableLogging()
+
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -54,6 +58,11 @@ func main() {
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
+	}
+
+	// Enable library-level logging if debug logging level is enabled app-wide
+	if cfg.LoggingLevel == config.LogLevelDebug {
+		vsphere.EnableLogging()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -100,8 +99,7 @@ func GetDatastores(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo
 	var dss []mo.Datastore
 
 	defer func(dss *[]mo.Datastore) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetDatastores func (and retrieve %d Datastores).\n",
 			time.Since(funcTimeStart),
 			len(*dss),
@@ -131,8 +129,7 @@ func GetDatastoreByName(ctx context.Context, c *vim25.Client, dsName string, dat
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetDatastoreByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -157,8 +154,7 @@ func FilterDatastoreByName(dss []mo.Datastore, dsName string) (mo.Datastore, err
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterDatastoreByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -189,8 +185,7 @@ func FilterDatastoreByID(dss []mo.Datastore, dsID string) (mo.Datastore, error) 
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterDatastoreByID func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -248,8 +243,7 @@ func DatastoreUsageOneLineCheckSummary(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute DatastoreUsageOneLineCheckSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -282,8 +276,7 @@ func DatastoreUsageReport(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute DatastoreUsageReport func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/vmware/govmomi/find"
@@ -93,8 +92,7 @@ func getObjects(ctx context.Context, c *vim25.Client, dst interface{}, objRef ty
 	// length checks in type switch below
 	var objCount int
 	defer func(count *int, kind *string) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute getObjects func (and retrieve %d %s objects).\n",
 			time.Since(funcTimeStart),
 			*count,
@@ -215,8 +213,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 	var objKind string
 
 	defer func(kind *string) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute getObjectByName func (and retrieve %s object).\n",
 			time.Since(funcTimeStart),
 			*kind,

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -9,7 +9,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -253,8 +252,7 @@ func VirtualHardwareOneLineCheckSummary(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VirtualHardwareOneLineCheckSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -304,8 +302,7 @@ func VirtualHardwareReport(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VirtualHardwareReport func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -376,8 +376,7 @@ func H2D2VMsOneLineCheckSummary(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute H2D2VMsOneLineCheckSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -432,8 +431,7 @@ func H2D2VMsReport(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute HostToDatastoresToVMsReport func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -10,7 +10,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -33,8 +32,7 @@ func GetHostSystems(ctx context.Context, c *vim25.Client, propsSubset bool) ([]m
 	var hss []mo.HostSystem
 
 	defer func(hss *[]mo.HostSystem) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetHostSystems func (and retrieve %d HostSystems).\n",
 			time.Since(funcTimeStart),
 			len(*hss),
@@ -64,8 +62,7 @@ func GetHostSystemByName(ctx context.Context, c *vim25.Client, hsName string, da
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetHostSystemByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -90,8 +87,7 @@ func FilterHostSystemByName(hss []mo.HostSystem, hsName string) (mo.HostSystem, 
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterHostSystemByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -122,8 +118,7 @@ func FilterHostSystemByID(hss []mo.HostSystem, hsID string) (mo.HostSystem, erro
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterHostSystemByID func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/init.go
+++ b/internal/vsphere/init.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package vsphere
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// logger is a package logger that can be enabled from client code to allow
+// logging output from this package when desired/needed for troubleshooting
+var logger *log.Logger
+
+func init() {
+	// Disable logging output by default unless client code explicitly
+	// requests it
+	logger = log.New(os.Stderr, "[vsphere] ", 0)
+	logger.SetOutput(ioutil.Discard)
+}
+
+// EnableLogging enables logging output from this package. Output is muted by
+// default unless explicitly requested (by calling this function).
+func EnableLogging() {
+	logger.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	logger.SetOutput(os.Stderr)
+}
+
+// DisableLogging reapplies default package-level logging settings of muting
+// all logging output.
+func DisableLogging() {
+	logger.SetFlags(0)
+	logger.SetOutput(ioutil.Discard)
+}

--- a/internal/vsphere/networks.go
+++ b/internal/vsphere/networks.go
@@ -10,7 +10,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -34,8 +33,7 @@ func GetNetworks(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo.N
 	var nets []mo.Network
 
 	defer func(nets *[]mo.Network) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetNetworks func (and retrieve %d Networks).\n",
 			time.Since(funcTimeStart),
 			len(*nets),
@@ -65,8 +63,7 @@ func GetNetworkByName(ctx context.Context, c *vim25.Client, netName string, data
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetNetworkByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -91,8 +88,7 @@ func FilterNetworkByName(nets []mo.Network, netName string) (mo.Network, error) 
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterNetworkByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -123,8 +119,7 @@ func FilterNetworkByID(nets []mo.Network, netID string) (mo.Network, error) {
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterNetworkByID func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -10,7 +10,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -31,8 +30,7 @@ func ValidateRPs(ctx context.Context, c *vim25.Client, includeRPs []string, excl
 	funcTimeStart := time.Now()
 
 	defer func(irps []string, erps []string) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute ValidateRPs func (and validate %d Resource Pools).\n",
 			time.Since(funcTimeStart),
 			len(irps)+len(erps),
@@ -147,8 +145,7 @@ func GetEligibleRPs(ctx context.Context, c *vim25.Client, includeRPs []string, e
 	var rps []mo.ResourcePool
 
 	defer func(rps *[]mo.ResourcePool) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetEligibleRPs func (and retrieve %d Resource Pools).\n",
 			time.Since(funcTimeStart),
 			len(*rps),
@@ -223,8 +220,7 @@ func GetRPByName(ctx context.Context, c *vim25.Client, rpName string, datacenter
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetRPByName func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/tools.go
+++ b/internal/vsphere/tools.go
@@ -9,7 +9,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -28,8 +27,7 @@ func GetVMToolsStatusSummary(vms []mo.VirtualMachine) (string, int) {
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetVMToolsStatusSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -88,8 +86,7 @@ func FilterVMsWithToolsIssues(vms []mo.VirtualMachine) []mo.VirtualMachine {
 	funcTimeStart := time.Now()
 
 	defer func(vms []mo.VirtualMachine, filteredVMs *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterVMsWithToolsIssues func (for %d VMs, yielding %d VMs).\n",
 			time.Since(funcTimeStart),
 			len(vms),
@@ -114,8 +111,7 @@ func VMToolsOneLineCheckSummary(stateLabel string, vmsWithIssues []mo.VirtualMac
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VMToolsOneLineCheckSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -163,8 +159,7 @@ func VMToolsReport(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VMToolsReport func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -9,7 +9,6 @@ package vsphere
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -32,8 +31,7 @@ func VirtualCPUsOneLineCheckSummary(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VirtualCPUsOneLineCheckSummary func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -95,8 +93,7 @@ func VirtualCPUsReport(
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute VirtualCPUsReport func.\n",
 			time.Since(funcTimeStart),
 		)

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -10,7 +10,6 @@ package vsphere
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -37,8 +36,7 @@ func GetVMs(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo.Virtua
 	var vms []mo.VirtualMachine
 
 	defer func(vms *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetVMs func (and retrieve %d VirtualMachines).\n",
 			time.Since(funcTimeStart),
 			len(*vms),
@@ -73,8 +71,7 @@ func GetVMsFromRPs(ctx context.Context, c *vim25.Client, rps []mo.ResourcePool, 
 	var vms []mo.VirtualMachine
 
 	defer func(vms *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetVMsFromRPs func (and retrieve %d VMs).\n",
 			time.Since(funcTimeStart),
 			len(*vms),
@@ -121,8 +118,7 @@ func GetVMsFromDatastore(ctx context.Context, c *vim25.Client, ds mo.Datastore, 
 	dsVMs := make([]mo.VirtualMachine, len(ds.Vm))
 
 	defer func(vms *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetVMsFromDatastore func (and retrieve %d VMs).\n",
 			time.Since(funcTimeStart),
 			len(*vms),
@@ -171,8 +167,7 @@ func GetVMByName(ctx context.Context, c *vim25.Client, vmName string, datacenter
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute GetVMByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -197,8 +192,7 @@ func FilterVMByName(vms []mo.VirtualMachine, vmName string) (mo.VirtualMachine, 
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterVMByName func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -229,8 +223,7 @@ func FilterVMByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, erro
 	funcTimeStart := time.Now()
 
 	defer func() {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterVMByID func.\n",
 			time.Since(funcTimeStart),
 		)
@@ -297,8 +290,7 @@ func FilterVMsByPowerState(vms []mo.VirtualMachine, includePoweredOff bool) []mo
 	funcTimeStart := time.Now()
 
 	defer func(vms []mo.VirtualMachine, filteredVMs *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute FilterVMsByPowerState func (for %d VMs, yielding %d VMs)\n",
 			time.Since(funcTimeStart),
 			len(vms),
@@ -340,8 +332,7 @@ func dedupeVMs(vmsList []mo.VirtualMachine) []mo.VirtualMachine {
 	funcTimeStart := time.Now()
 
 	defer func(vms *[]mo.VirtualMachine) {
-		fmt.Fprintf(
-			os.Stderr,
+		logger.Printf(
 			"It took %v to execute dedupeVMs func (evaluated %d VMs).\n",
 			time.Since(funcTimeStart),
 			len(*vms),


### PR DESCRIPTION
- Implement package level logger
- Disable new package level logger by default
- Replace `fmt.Fprint*` calls with `logger.Print*` variant calls

fixes GH-76