### PR TITLE
Fix snapshots summary details

### DIFF
--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -238,8 +238,11 @@ func main() {
 
 	case snapshotSets.IsAgeCriticalState():
 
+		vmsWithOldSnapshots, oldSnapshots := snapshotSets.ExceedsAge(cfg.SnapshotsAgeCritical)
+
 		log.Error().
-			Int("num_snapshots_age_critical", snapshotSets.ExceedsAge(cfg.SnapshotsAgeCritical)).
+			Int("num_vms_with_critical_snapshots", vmsWithOldSnapshots).
+			Int("num_snapshots_age_critical", oldSnapshots).
 			Msg("Snapshot sets contain a snapshot which exceeds specified age in days")
 
 		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed
@@ -274,8 +277,11 @@ func main() {
 
 	case snapshotSets.IsAgeWarningState():
 
+		vmsWithOldSnapshots, oldSnapshots := snapshotSets.ExceedsAge(cfg.SnapshotsAgeWarning)
+
 		log.Error().
-			Int("num_snapshots_age_warning", snapshotSets.ExceedsAge(cfg.SnapshotsAgeWarning)).
+			Int("num_vms_with_warning_snapshots", vmsWithOldSnapshots).
+			Int("num_snapshots_age_warning", oldSnapshots).
 			Msg("Snapshot sets contain one or more snapshots which exceed specified age in days")
 
 		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -72,12 +72,12 @@ func main() {
 	// content is shown in the detailed web UI and in notifications generated
 	// by Nagios.
 	nagiosExitState.CriticalThreshold = fmt.Sprintf(
-		"%d GB size snapshots present",
+		"snapshots of %d GB (combined size) present",
 		cfg.SnapshotsSizeCritical,
 	)
 
 	nagiosExitState.WarningThreshold = fmt.Sprintf(
-		"%d GB size snapshots present",
+		"snapshots of %d GB (combined size) present",
 		cfg.SnapshotsSizeWarning,
 	)
 
@@ -238,8 +238,11 @@ func main() {
 
 	case snapshotSets.IsSizeCriticalState():
 
+		vmsWithLargeCumulativeSnapshots, largeSnapshots := snapshotSets.ExceedsSize(cfg.SnapshotsSizeCritical)
+
 		log.Error().
-			Int("num_snapshots_size_critical", snapshotSets.ExceedsSize(cfg.SnapshotsSizeCritical)).
+			Int("num_vms_with_critical_snapshots", vmsWithLargeCumulativeSnapshots).
+			Int("num_snapshots_size_critical", largeSnapshots).
 			Msg("Snapshot sets contain a snapshot which exceeds specified size in GB")
 
 		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
@@ -274,9 +277,12 @@ func main() {
 
 	case snapshotSets.IsSizeWarningState():
 
+		vmsWithLargeCumulativeSnapshots, largeSnapshots := snapshotSets.ExceedsSize(cfg.SnapshotsSizeWarning)
+
 		log.Error().
-			Int("num_snapshots_size_warning", snapshotSets.ExceedsSize(cfg.SnapshotsSizeWarning)).
-			Msg("Snapshot sets contain one or more snapshots which exceed specified size in GB")
+			Int("num_vms_with_warning_snapshots", vmsWithLargeCumulativeSnapshots).
+			Int("num_snapshots_size_warning", largeSnapshots).
+			Msg("Snapshot sets contain a snapshot which exceeds specified size in GB")
 
 		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
 


### PR DESCRIPTION
- Expose affected VMs count in one-line summary
- Expose evaluated snapshots count in one-line summary
- Continue to expose affected snapshots count in one-line
  summary, but attempt to tie the number directly to affected
  VMs (1 VM to one set of snapshots)
- Tweak thresholds listing to emphasize that thresholds are
  based on "combined" size
- Repurpose `ExceedsAge` and `ExceedsSize` `SnapshotSummarySets`
  methods to return the count of affected sets and how many
  snapshots in each set are affected

fixes GH-99