### PR TITLE
Fix variable name with stutter

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -72,7 +72,7 @@ const (
 
 	// Intentionally set low to trigger validation failure if not specified by
 	// the end user.
-	defaultVCPUsMaxAllowedAllowed int = 0
+	defaultVCPUsMaxAllowed int = 0
 
 	// Default timeout (in seconds) used when connecting to a remote server
 	defaultConnectTimeout int = 10

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -97,8 +97,8 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.IntVar(&c.VCPUsAllocatedCritical, "vcpus-critical", defaultVCPUsAllocatedCritical, vCPUsAllocatedCriticalFlagHelp)
 		flag.IntVar(&c.VCPUsAllocatedCritical, "vc", defaultVCPUsAllocatedCritical, vCPUsAllocatedCriticalFlagHelp+" (shorthand)")
 
-		flag.IntVar(&c.VCPUsMaxAllowed, "vcpus-max-allowed", defaultVCPUsMaxAllowedAllowed, vCPUsAllocatedMaxAllowedFlagHelp)
-		flag.IntVar(&c.VCPUsMaxAllowed, "vcma", defaultVCPUsMaxAllowedAllowed, vCPUsAllocatedMaxAllowedFlagHelp+" (shorthand)")
+		flag.IntVar(&c.VCPUsMaxAllowed, "vcpus-max-allowed", defaultVCPUsMaxAllowed, vCPUsAllocatedMaxAllowedFlagHelp)
+		flag.IntVar(&c.VCPUsMaxAllowed, "vcma", defaultVCPUsMaxAllowed, vCPUsAllocatedMaxAllowedFlagHelp+" (shorthand)")
 
 	case pluginType.VirtualHardwareVersion:
 


### PR DESCRIPTION
Replace variable with `AllowedAllowed` pattern with just `Allowed`.

A minor thing, but potentially confusing for a future reader.