### PR TITLE
Replace deprecated Resource Pool memory usage API

### DIFF
--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -195,10 +195,13 @@ func main() {
 
 	var aggregateMemoryUsage int64
 	for _, rp := range resourcePools {
-		aggregateMemoryUsage += rp.Runtime.Memory.OverallUsage
+		// Per vSphere API docs, `rp.Runtime.Memory.OverallUsage` was
+		// deprecated in v6.5, so we use `hostMemoryUsage` instead.
+		rpMemoryUsage := rp.Summary.GetResourcePoolSummary().QuickStats.HostMemoryUsage * units.MB
+		aggregateMemoryUsage += rpMemoryUsage
 		log.Debug().
 			Str("resource_pool_name", rp.Name).
-			Str("resource_pool_memory_usage", units.ByteSize(rp.Runtime.Memory.OverallUsage).String()).
+			Str("resource_pool_memory_usage", units.ByteSize(rpMemoryUsage).String()).
 			Msg("")
 	}
 

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -344,12 +344,13 @@ func ResourcePoolsMemoryReport(
 		nagios.CheckOutputEOL,
 	)
 	for _, rp := range rps {
-		rpMemoryPercentageUsed := MemoryUsedPercentage(rp.Runtime.Memory.OverallUsage, maxMemoryUsageInGB)
+		rpMemoryUsage := rp.Summary.GetResourcePoolSummary().QuickStats.HostMemoryUsage * units.MB
+		rpMemoryPercentageUsed := MemoryUsedPercentage(rpMemoryUsage, maxMemoryUsageInGB)
 		fmt.Fprintf(
 			&report,
 			"* %s (%s, %0.1f%%)%s",
 			rp.Name,
-			units.ByteSize(rp.Runtime.Memory.OverallUsage),
+			units.ByteSize(rpMemoryUsage),
 			rpMemoryPercentageUsed,
 			nagios.CheckOutputEOL,
 		)


### PR DESCRIPTION
Replace use of `vim.ResourcePool.ResourceUsage` (deprecated in vSphere 6.5) with `vim.ResourcePool.Summary.QuickStats` for obtaining Resource Pool memory usage value.

fixes GH-5