### PR TITLE
vCPUs plugin: Replace dynamic err with fixed err

### DIFF
--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -248,12 +248,7 @@ func main() {
 			Int("vms_filtered", len(filteredVMs)).
 			Msg("vCPUs allocation")
 
-		nagiosExitState.LastError = fmt.Errorf(
-			"%d of %d vCPUs allocated (%0.1f%% more than allowed)",
-			vCPUsAllocated,
-			cfg.VCPUsMaxAllowed,
-			vCPUsPercentageUsedOfAllowed,
-		)
+		nagiosExitState.LastError = vsphere.ErrVCPUsUsageThresholdCrossed
 
 		nagiosExitState.ServiceOutput = vsphere.VirtualCPUsOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -287,12 +282,7 @@ func main() {
 			Int("vms_filtered", len(filteredVMs)).
 			Msg("vCPUs allocation warning")
 
-		nagiosExitState.LastError = fmt.Errorf(
-			"%d of %d vCPUs allocated (%0.1f%% more than allowed)",
-			vCPUsAllocated,
-			cfg.VCPUsMaxAllowed,
-			vCPUsPercentageUsedOfAllowed,
-		)
+		nagiosExitState.LastError = vsphere.ErrVCPUsUsageThresholdCrossed
 
 		nagiosExitState.ServiceOutput = vsphere.VirtualCPUsOneLineCheckSummary(
 			nagios.StateWARNINGLabel,

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -8,6 +8,7 @@
 package vsphere
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -16,6 +17,10 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 )
+
+// ErrVCPUsUsageThresholdCrossed indicates that specified
+// vCPUs allocation has exceeded a given threshold
+var ErrVCPUsUsageThresholdCrossed = errors.New("vCPUS allocation exceeds specified threshold")
 
 // VirtualCPUsOneLineCheckSummary is used to generate a one-line Nagios
 // service check results summary. This is the line most prominent in


### PR DESCRIPTION
The previous dynamic content mirrored the one-line summary output, but also introduced potential confusion. This update replaces that content with a fixed error string that hopefully is more direct and makes clear what the error condition is.

fixes GH-104