### PR TITLE
Minor tweak for memory overage description

### DIFF
--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -284,7 +284,7 @@ func RPMemoryUsageOneLineCheckSummary(
 	case aggregateMemoryUsage > memoryUsageMax:
 		memoryOverage := aggregateMemoryUsage - memoryUsageMax
 		return fmt.Sprintf(
-			"%s: %s memory used (%.1f%%); %s more allocated than "+
+			"%s: %s memory used (%.1f%%); %s more used than "+
 				"%s allowed (evaluated %d Resource Pools)",
 			stateLabel,
 			units.ByteSize(aggregateMemoryUsage),


### PR DESCRIPTION
Say "used" (implies dynamic) instead of "allocated" (implies fixed value).