### PR TITLE
Fix snapshots age misordered eval counts

### DIFF
--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -857,8 +857,8 @@ func SnapshotsAgeOneLineCheckSummary(
 			"%s: No snapshots older than %d days detected (evaluated %d VMs, %d Snapshots, %d Resource Pools)",
 			stateLabel,
 			snapshotsAgeWarning,
-			snapshotSets.Snapshots(),
 			len(evaluatedVMs),
+			snapshotSets.Snapshots(),
 			len(rps),
 		)
 


### PR DESCRIPTION
Previous "OK: No snapshots older than X" message had an incorrect "evaluated" listing due to misordered substitution list. This commit sorts that issue.