### PR TITLE
List Resource Pool usage as percent of total capacity

### DIFF
--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -58,6 +58,8 @@ func getHostSystemPropsSubset() []string {
 	// https://code.vmware.com/apis/1067/vsphere
 	// https://vdc-download.vmware.com/vmwb-repository/dcr-public/a5f4000f-1ea8-48a9-9221-586adff3c557/7ff50256-2cf2-45ea-aacd-87d231ab1ac7/vim.HostSystem.html
 	return []string{
+		"hardware", // memory capacity
+		"runtime",  // connection, power state details
 		"summary",
 		"vm",
 		"name",


### PR DESCRIPTION
Expose percentage of total capacity usage for all Resource
Pools in the one-line summary (Service Output) and per-pool
usage of total capacity in the extended (Long Service Output)
output.

Changes of note:

- Extend properties retrieved for `HostSystem` type
  - `hardware`
  - `runtime`
- Add `GetHostSystemsTotalMemory` func with optional support
  for excluding offline systems
- Drop "overage" detail from one-line summary, relying instead
  on existing percentage detail to convey overage (e.g.,
  114% usage implies 14% over)
- Tweak one-line summary messages to in an effort to simplify
  wording

fixes GH-110