### PR TITLE
Fix invalid ExceedsAge logic

### DIFF
--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -226,7 +226,7 @@ func (sss SnapshotSummarySets) ExceedsAge(days int) (int, int) {
 	var setsExceeded int
 	var snapshotsExceeded int
 	for _, set := range sss {
-		if set.ExceedsAge(days) > 1 {
+		if set.ExceedsAge(days) >= 1 {
 			setsExceeded++
 			snapshotsExceeded += set.ExceedsAge(days)
 		}


### PR DESCRIPTION
This change resolves invalid logic which led to misreported VMs, snapshots.

In our situation it led to counts that were off by 2 for VMs and snapshots.

fixes GH-117