### PR TITLE
Add initial draft of snapshots count plugin

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -88,5 +88,6 @@ jobs:
           go build -v -mod=vendor ./cmd/check_vmware_hs2ds2vms
           go build -v -mod=vendor ./cmd/check_vmware_datastore
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_age
+          go build -v -mod=vendor ./cmd/check_vmware_snapshots_count
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_size
           go build -v -mod=vendor ./cmd/check_vmware_rps_memory

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ scratch/
 /check_vmware_hs2ds2vms
 /check_vmware_datastore
 /check_vmware_snapshots_age
+/check_vmware_snapshots_count
 /check_vmware_snapshots_size
 /check_vmware_rps_memory

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ WHAT 					= check_vmware_tools \
 							check_vmware_hs2ds2vms \
 							check_vmware_datastore \
 							check_vmware_snapshots_age \
+							check_vmware_snapshots_count \
 							check_vmware_snapshots_size \
 							check_vmware_rps_memory \
 

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -218,6 +218,11 @@ func main() {
 	log.Debug().Msg("Build snapshot sets for bulk processing")
 	snapshotSets := make(vsphere.SnapshotSummarySets, 0, len(vmsWithSnapshots))
 
+	snapshotThresholds := vsphere.SnapshotThresholds{
+		AgeCritical: cfg.SnapshotsAgeCritical,
+		AgeWarning:  cfg.SnapshotsAgeWarning,
+	}
+
 	for _, vm := range vmsWithSnapshots {
 
 		log.Debug().Str("vm", vm.Name).Msg("Evaluating snapshots for VM")
@@ -226,10 +231,7 @@ func main() {
 			snapshotSets,
 			vsphere.NewSnapshotSummarySet(
 				vm,
-				cfg.SnapshotsAgeCritical,
-				cfg.SnapshotsAgeWarning,
-				cfg.SnapshotsSizeCritical,
-				cfg.SnapshotsSizeWarning,
+				snapshotThresholds,
 			),
 		)
 	}
@@ -250,8 +252,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -259,8 +260,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -289,8 +289,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -298,8 +297,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -321,8 +319,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -330,8 +327,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			cfg.SnapshotsAgeCritical,
-			cfg.SnapshotsAgeWarning,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/cmd/check_vmware_snapshots_count/doc.go
+++ b/cmd/check_vmware_snapshots_count/doc.go
@@ -1,0 +1,34 @@
+/*
+
+Nagios plugin used to monitor the number of snapshots per Virtual Machine.
+
+PURPOSE
+
+Monitor the number of snapshots for each Virtual Machine. VMware recommends
+using no more than 3 or 4 snapshots per Virtual Machine and only for a limited
+duration. A maximum of 32 snapshots per Virtual Machine are supported. See
+https://kb.vmware.com/s/article/1025279 for more information.
+
+The current design of this plugin is to evaluate *all* Virtual Machines,
+whether powered off or powered on. If you have a use case for evaluating
+*only* powered on VMs by default, please add a comment to
+https://github.com/atc0005/check-vmware/issues/79 providing some details for
+your use-case.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -56,6 +56,7 @@ contrib
         │       ├── vmware-host-datastore-vms-pairings.cfg
         │       ├── vmware-resource-pools.cfg
         │       ├── vmware-snapshots-age.cfg
+        │       ├── vmware-snapshots-count.cfg
         │       ├── vmware-snapshots-size.cfg
         │       ├── vmware-tools.cfg
         │       ├── vmware-vcpus.cfg
@@ -86,7 +87,7 @@ contrib
             ├── nagios.cfg
             └── resource.cfg
 
-13 directories, 26 files
+13 directories, 27 files
 ```
 
 ### Overview

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-count.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-count.cfg
@@ -1,0 +1,33 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Look at specific pools, exclude other pools
+define command{
+    command_name    check_vmware_snapshots_count_include_pools
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    }
+
+# Look at specific pools, exclude other pools, exclude list of VMs
+define command{
+    command_name    check_vmware_snapshots_count_include_pools_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    }
+
+# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally.
+define command{
+    command_name    check_vmware_snapshots_count
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --trust-cert --log-level info
+    }
+
+# Look at all pools, exclude list of VMs
+define command{
+    command_name    check_vmware_snapshots_count_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    }

--- a/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
+++ b/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
@@ -51,6 +51,20 @@ define service{
 define service{
     use                     vmware-vsphere-service
     host_name               vc1.exmaple.com
+    service_description     VMware Snapshots - Count
+    servicegroups           vmware-checks, vmware-snapshot-checks
+    check_command           check_vmware_snapshots_count_include_pools_exclude_vms!example!vc1-read-only-service-account!$USER13$!4!25!"Desktops", "Server Support"!RHEL7-TEST
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning threshold in snapshots count (e.g., 4)
+    # Argument 5: Critical threshold in snapshots count (e.g., 25 of 32 max)
+    # Argument 6: Comma-separated list of VMs (full names) that are to be ignored
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
     service_description     VMware Snapshots - Size
     servicegroups           vmware-checks, vmware-snapshot-checks
     check_command           check_vmware_snapshots_size_include_pools!example!vc1-read-only-service-account!$USER13$!30!50!"Desktops", "Server Support"

--- a/doc.go
+++ b/doc.go
@@ -30,6 +30,8 @@ hosts or vCenter instances) for select (or all) Resource Pools.
 
 • Snapshots age
 
+• Snapshots count
+
 • Snapshots size
 
 • Resource Pools: Memory usage

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ var ErrVersionRequested = errors.New("version information requested")
 type PluginType struct {
 	Tools                  bool
 	SnapshotsAge           bool
+	SnapshotsCount         bool
 	SnapshotsSize          bool
 	DatastoresSize         bool
 	ResourcePoolsMemory    bool
@@ -216,6 +217,14 @@ type Config struct {
 	// SnapshotsAgeCritical specifies the age of a snapshot in days when a
 	// CRITICAL threshold is reached.
 	SnapshotsAgeCritical int
+
+	// SnapshotsCountWarning specifies the number of snapshots per VM when a
+	// WARNING threshold is reached.
+	SnapshotsCountWarning int
+
+	// SnapshotsCountCritical specifies the number of snapshots per VM when a
+	// CRITICAL threshold is reached.
+	SnapshotsCountCritical int
 
 	// IgnoreMissingCustomAttribute indicates whether a host or datastore
 	// missing the specified Custom Attribute should be ignored.

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -42,6 +42,8 @@ const (
 	datacenterNameFlagHelp                          string = "Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts."
 	snapshotsAgeCriticalFlagHelp                    string = "Specifies the age of a snapshot in days when a CRITICAL threshold is reached."
 	snapshotsAgeWarningFlagHelp                     string = "Specifies the age of a snapshot in days when a WARNING threshold is reached."
+	snapshotsCountCriticalFlagHelp                  string = "Specifies the number of snapshots per VM when a CRITICAL threshold is reached."
+	snapshotsCountWarningFlagHelp                   string = "Specifies the number of snapshots per VM when a WARNING threshold is reached."
 	snapshotsSizeCriticalFlagHelp                   string = "Specifies the cumulative size in GB of all snapshots for a Virtual Machine when a CRITICAL threshold is reached."
 	snapshotsSizeWarningFlagHelp                    string = "Specifies the cumulative size in GB of all snapshots for a Virtual Machine when a WARNING threshold is reached."
 	resourcePoolsMemoryMaxAllowedFlagHelp           string = "Specifies the maximum amount of memory that we are allowed to consume in GB (as a whole number) in the target VMware environment across all specified Resource Pools. VMs that are running outside of resource pools are not considered in these calculations."
@@ -70,6 +72,8 @@ const (
 	defaultDatacenterName               string = ""
 	defaultSnapshotsAgeCritical         int    = 2
 	defaultSnapshotsAgeWarning          int    = 1
+	defaultSnapshotsCountCritical       int    = 25 // max is 32
+	defaultSnapshotsCountWarning        int    = 4  // recommended cap is 3-4
 	defaultSnapshotsSizeCritical        int    = 40 // size in GB
 	defaultSnapshotsSizeWarning         int    = 20 // size in GB
 	defaultMemoryUseCritical            int    = 95
@@ -109,6 +113,7 @@ const (
 const (
 	PluginTypeTools                    string = "vmware-tools"
 	PluginTypeSnapshotsAge             string = "snapshots-age"
+	PluginTypeSnapshotsCount           string = "snapshots-count"
 	PluginTypeSnapshotsSize            string = "snapshots-size"
 	PluginTypeDatastoresSize           string = "datastore-size"
 	PluginTypeResourcePoolsMemory      string = "resource-pools-memory"

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -46,6 +46,27 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.IntVar(&c.SnapshotsAgeCritical, "ac", defaultSnapshotsAgeCritical, snapshotsAgeCriticalFlagHelp)
 		flag.IntVar(&c.SnapshotsAgeCritical, "age-critical", defaultSnapshotsAgeCritical, snapshotsAgeCriticalFlagHelp)
 
+	case pluginType.SnapshotsCount:
+
+		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)
+		flag.Var(&c.ExcludedResourcePools, "exclude-rp", excludedResourcePoolsFlagHelp)
+		flag.Var(&c.IgnoredVMs, "ignore-vm", ignoreVMsFlagHelp)
+
+		// NOTE: This plugin is hard-coded to evaluate powered off and powered
+		// on VMs equally. I'm not sure whether ignoring powered off VMs by
+		// default makes sense for this particular plugin.
+		//
+		// Please share your feedback on this GitHub issue if you feel differently:
+		// https://github.com/atc0005/check-vmware/issues/79
+		//
+		// flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
+
+		flag.IntVar(&c.SnapshotsCountWarning, "cw", defaultSnapshotsCountWarning, snapshotsCountWarningFlagHelp)
+		flag.IntVar(&c.SnapshotsCountWarning, "count-warning", defaultSnapshotsCountWarning, snapshotsCountWarningFlagHelp)
+
+		flag.IntVar(&c.SnapshotsCountCritical, "cc", defaultSnapshotsCountCritical, snapshotsCountCriticalFlagHelp)
+		flag.IntVar(&c.SnapshotsCountCritical, "count-critical", defaultSnapshotsCountCritical, snapshotsCountCriticalFlagHelp)
+
 	case pluginType.SnapshotsSize:
 
 		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -101,6 +101,9 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	case pluginType.SnapshotsAge:
 		appDescription = PluginTypeSnapshotsAge
 
+	case pluginType.SnapshotsCount:
+		appDescription = PluginTypeSnapshotsCount
+
 	case pluginType.SnapshotsSize:
 		appDescription = PluginTypeSnapshotsSize
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -48,6 +48,34 @@ func (c Config) validate(pluginType PluginType) error {
 			)
 		}
 
+	case pluginType.SnapshotsCount:
+
+		if c.SnapshotsCountWarning < 0 {
+			return fmt.Errorf(
+				"invalid snapshot count WARNING threshold number: %d",
+				c.SnapshotsCountWarning,
+			)
+		}
+
+		if c.SnapshotsCountCritical < 0 {
+			return fmt.Errorf(
+				"invalid snapshot count CRITICAL threshold number: %d",
+				c.SnapshotsCountCritical,
+			)
+		}
+
+		if c.SnapshotsCountCritical < c.SnapshotsCountWarning {
+			return fmt.Errorf(
+				"critical threshold set lower than warning threshold",
+			)
+		}
+
+		if c.SnapshotsCountCritical == c.SnapshotsCountWarning {
+			return fmt.Errorf(
+				"critical threshold set equal to warning threshold",
+			)
+		}
+
 	case pluginType.SnapshotsSize:
 
 		if c.SnapshotsSizeWarning < 0 {

--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -37,12 +37,14 @@ const (
 
 // used with snapshots reports that provide Long Service Output
 const (
-	snapshotThresholdTypeAge  string = "age"
-	snapshotThresholdTypeSize string = "size"
+	snapshotThresholdTypeAge   string = "age"
+	snapshotThresholdTypeCount string = "count"
+	snapshotThresholdTypeSize  string = "size"
 )
 
 // used with snapshots reports that provide Long Service Output
 const (
-	snapshotThresholdTypeAgeSuffix  string = "d"
-	snapshotThresholdTypeSizeSuffix string = "GB"
+	snapshotThresholdTypeAgeSuffix   string = "day"
+	snapshotThresholdTypeCountSuffix string = "snapshots"
+	snapshotThresholdTypeSizeSuffix  string = "GB"
 )


### PR DESCRIPTION
As with several other plugins in this project, this one borrows
heavily from existing projects. In particular, this plugin is based
heavily on the snapshots age and size plugins. Small adjustments were
made to shared code in order to support the new plugin.

In short, this plugin monitors the snapshots count per Virtual Machine
for all specified Resource Pools. As with the snapshots age and size
plugins, Resource Pools can be explicitly included or excluded and
individual Virtual Machines can be ignored/excluded from evaluation.

Doc updates have been applied, example usage has been added, including
a command definition "contrib" file illustrating how the plugin would
be referenced within a production Nagios configuration.

fixes GH-66