### PR TITLE
Refresh threshold details

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -72,12 +72,12 @@ func main() {
 	// content is shown in the detailed web UI and in notifications generated
 	// by Nagios.
 	nagiosExitState.CriticalThreshold = fmt.Sprintf(
-		"%d%% of datastore usage allocated",
+		"%d%% datastore usage",
 		cfg.DatastoreUsageCritical,
 	)
 
 	nagiosExitState.WarningThreshold = fmt.Sprintf(
-		"%d%% of datastore usage allocated",
+		"%d%% datastore usage",
 		cfg.DatastoreUsageWarning,
 	)
 

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -72,12 +72,12 @@ func main() {
 	// content is shown in the detailed web UI and in notifications generated
 	// by Nagios.
 	nagiosExitState.CriticalThreshold = fmt.Sprintf(
-		"more than %d snapshots present",
+		"%d snapshots present",
 		cfg.SnapshotsCountCritical,
 	)
 
 	nagiosExitState.WarningThreshold = fmt.Sprintf(
-		"more than %d snapshots present",
+		"%d snapshots present",
 		cfg.SnapshotsCountWarning,
 	)
 


### PR DESCRIPTION
Minor tweaks to threshold descriptions in an effort to more
clearly indicate what is the threshold and not what pushes
the service check *over* the threshold.

fixes GH-119