### PR TITLE
Add initial draft of host memory monitoring plugin

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -91,3 +91,4 @@ jobs:
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_count
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_size
           go build -v -mod=vendor ./cmd/check_vmware_rps_memory
+          go build -v -mod=vendor ./cmd/check_vmware_host_memory

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ scratch/
 /check_vmware_snapshots_count
 /check_vmware_snapshots_size
 /check_vmware_rps_memory
+/check_vmware_host_memory

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ WHAT 					= check_vmware_tools \
 							check_vmware_snapshots_count \
 							check_vmware_snapshots_size \
 							check_vmware_rps_memory \
+							check_vmware_host_memory \
 
 
 # What package holds the "version" variable used in branding/version output?

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ or endorsed by VMware, Inc.
     - [`check_vmware_snapshots_count`](#check_vmware_snapshots_count)
     - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size)
     - [`check_vmware_rps_memory`](#check_vmware_rps_memory)
+    - [`check_vmware_host_memory`](#check_vmware_host_memory)
   - [Features](#features)
   - [Changelog](#changelog)
   - [Requirements](#requirements)
@@ -44,6 +45,7 @@ or endorsed by VMware, Inc.
       - [`check_vmware_snapshots_count`](#check_vmware_snapshots_count-1)
       - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size-1)
       - [`check_vmware_rps_memory`](#check_vmware_rps_memory-1)
+      - [`check_vmware_host_memory`](#check_vmware_host_memory-1)
     - [Command-line arguments](#command-line-arguments)
       - [`check_vmware_tools`](#check_vmware_tools-2)
       - [`check_vmware_vcpus`](#check_vmware_vcpus-2)
@@ -54,6 +56,7 @@ or endorsed by VMware, Inc.
       - [`check_vmware_snapshots_count`](#check_vmware_snapshots_count-2)
       - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size-2)
       - [`check_vmware_rps_memory`](#check_vmware_rps_memory-2)
+      - [`check_vmware_host_memory`](#check_vmware_host_memory-2)
     - [Configuration file](#configuration-file)
   - [Contrib](#contrib)
   - [Examples](#examples)
@@ -84,6 +87,9 @@ or endorsed by VMware, Inc.
     - [`check_vmware_rps_memory` Nagios plugin](#check_vmware_rps_memory-nagios-plugin)
       - [CLI invocation](#cli-invocation-8)
       - [Command definition](#command-definition-8)
+    - [`check_vmware_host_memory` Nagios plugin](#check_vmware_host_memory-nagios-plugin)
+      - [CLI invocation](#cli-invocation-9)
+      - [Command definition](#command-definition-9)
   - [License](#license)
   - [References](#references)
 
@@ -111,6 +117,7 @@ This repo contains various tools used to monitor/validate VMware environments.
 | `check_vmware_snapshots_count` | Alpha  | Nagios plugin used to monitor the count of Virtual Machine snapshots.               |
 | `check_vmware_snapshots_size`  | Alpha  | Nagios plugin used to monitor the **cumulative** size of Virtual Machine snapshots. |
 | `check_vmware_rps_memory`      | Alpha  | Nagios plugin used to monitor memory usage across Resource Pools.                   |
+| `check_vmware_host_memory`     | Alpha  | Nagios plugin used to monitor memory usage for a specific ESXi host system.         |
 
 The output for these plugins is designed to provide the one-line summary
 needed by Nagios for quick identification of a problem while providing longer,
@@ -269,6 +276,18 @@ Thresholds for `CRITICAL` and `WARNING` memory usage have usable defaults, but
 max memory usage is required before this plugin can be used. See the
 [configuration options](#configuration-options) section for details.
 
+### `check_vmware_host_memory`
+
+Nagios plugin used to monitor ESXi host memory.
+
+In addition to reporting current host memory usage, this plugin also reports
+which VMs are on the host (running or not), how much memory each VM is using
+as a fixed value and as a percentage of the host's total memory.
+
+Thresholds for `CRITICAL` and `WARNING` memory usage have usable defaults, but
+max memory usage is required before this plugin can be used. See the
+[configuration options](#configuration-options) section for details.
+
 ## Features
 
 - Multiple plugins for monitoring VMware vSphere environments (standalone ESXi
@@ -282,6 +301,7 @@ max memory usage is required before this plugin can be used. See the
   - Snapshots count
   - Snapshots size
   - Resource Pools: Memory usage
+  - Host Memory usage
 
 - Optional, leveled logging using `rs/zerolog` package
   - JSON-format output (to `stderr`)
@@ -363,6 +383,7 @@ been tested.
      - `go build -mod=vendor ./cmd/check_vmware_snapshots_count/`
      - `go build -mod=vendor ./cmd/check_vmware_snapshots_size/`
      - `go build -mod=vendor ./cmd/check_vmware_rps_memory/`
+     - `go build -mod=vendor ./cmd/check_vmware_host_memory/`
    - for all supported platforms (where `make` is installed)
       - `make all`
    - for use on Windows
@@ -382,6 +403,7 @@ been tested.
      - look in `/tmp/check-vmware/release_assets/check_vmware_snapshots_count/`
      - look in `/tmp/check-vmware/release_assets/check_vmware_snapshots_size/`
      - look in `/tmp/check-vmware/release_assets/check_vmware_rps_memory/`
+     - look in `/tmp/check-vmware/release_assets/check_vmware_host_memory/`
    - if using `go build`
      - look in `/tmp/check-vmware/`
 1. Review [configuration options](#configuration-options),
@@ -463,6 +485,14 @@ been tested.
 | `OK`         | Ideal state, memory usage across Resources Pools within bounds. |
 | `WARNING`    | Memory usage crossed user-specified threshold for this state.   |
 | `CRITICAL`   | Memory usage crossed user-specified threshold for this state.   |
+
+#### `check_vmware_host_memory`
+
+| Nagios State | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| `OK`         | Ideal state, memory usage for the specified ESXi host system is within bounds. |
+| `WARNING`    | Memory usage crossed user-specified threshold for this state.                  |
+| `CRITICAL`   | Memory usage crossed user-specified threshold for this state.                  |
 
 ### Command-line arguments
 
@@ -665,6 +695,26 @@ been tested.
 | `mma`, `memory-max-allowed` | **Yes**  | `0`     | No     | *positive whole number of vCPUs*                                        | Specifies the maximum amount of memory that we are allowed to consume in GB (as a whole number) in the target VMware environment across all specified Resource Pools. VMs that are running outside of resource pools are not considered in these calculations.                                                             |
 | `mc`, `memory-use-critical` | No       | `95`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) across all specified Resource Pools when a CRITICAL threshold is reached.                                                                                                                                                                                       |
 | `mw`, `memory-use-warning`  | No       | `100`   | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) across all specified Resource Pools when a WARNING threshold is reached.                                                                                                                                                                                        |
+
+#### `check_vmware_host_memory`
+
+| Flag                          | Required | Default | Repeat | Possible                                                                | Description                                                                                                                                                                                            |
+| ----------------------------- | -------- | ------- | ------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `branding`                    | No       | `false` | No     | `branding`                                                              | Toggles emission of branding details with plugin status details. This output is disabled by default.                                                                                                   |
+| `h`, `help`                   | No       | `false` | No     | `h`, `help`                                                             | Show Help text along with the list of supported flags.                                                                                                                                                 |
+| `v`, `version`                | No       | `false` | No     | `v`, `version`                                                          | Whether to display application version and then immediately exit application.                                                                                                                          |
+| `ll`, `log-level`             | No       | `info`  | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Log message priority filter. Log messages with a lower level are ignored.                                                                                                                              |
+| `p`, `port`                   | No       | `443`   | No     | *positive whole number between 1-65535, inclusive*                      | TCP port of the remote ESXi host or vCenter instance. This is usually 443 (HTTPS).                                                                                                                     |
+| `t`, `timeout`                | No       | `10`    | No     | *positive whole number of seconds*                                      | Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned.                                                                                                 |
+| `s`, `server`                 | **Yes**  |         | No     | *fully-qualified domain name or IP Address*                             | The fully-qualified domain name or IP Address of the remote ESXi host or vCenter instance.                                                                                                             |
+| `u`, `username`               | **Yes**  |         | No     | *valid username*                                                        | Username with permission to access specified ESXi host or vCenter instance.                                                                                                                            |
+| `pw`, `password`              | **Yes**  |         | No     | *valid password*                                                        | Password used to login to ESXi host or vCenter instance.                                                                                                                                               |
+| `domain`                      | No       |         | No     | *valid user domain*                                                     | (Optional) domain for user account used to login to ESXi host or vCenter instance.                                                                                                                     |
+| `trust-cert`                  | No       | `false` | No     | `true`, `false`                                                         | Whether the certificate should be trusted as-is without validation. WARNING: TLS is susceptible to man-in-the-middle attacks if enabling this option.                                                  |
+| `dc-name`                     | No       |         | No     | *valid vSphere datacenter name*                                         | Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts. |
+| `host-name`                   | **Yes**  |         | No     | *valid ESXi host name*                                                  | ESXi host/server name as it is found within the vSphere inventory.                                                                                                                                     |
+| `mc`, `memory-usage-critical` | No       | `95`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) when a CRITICAL threshold is reached.                                                                                                       |
+| `mw`, `memory-usage-warning`  | No       | `80`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) when a WARNING threshold is reached.                                                                                                        |
 
 ### Configuration file
 
@@ -948,7 +998,6 @@ define command{
     command_name    check_vmware_datastore
     command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ds-usage-warning '$ARG4$' --ds-usage-critical '$ARG5$' --ds-name '$ARG6$' --trust-cert  --log-level info
     }
-
 ```
 
 See the [configuration options](#configuration-options) section for all
@@ -1134,6 +1183,44 @@ See the [configuration options](#configuration-options) section for all
 command-line settings supported by this plugin along with descriptions of
 each. See the [contrib](#contrib) section for information regarding example
 command definitions and Nagios configuration files.
+
+### `check_vmware_host_memory` Nagios plugin
+
+#### CLI invocation
+
+```ShellSession
+/usr/lib/nagios/plugins/check_vmware_host_memory --username SERVICE_ACCOUNT_NAME --password "SERVICE_ACCOUNT_PASSWORD" --server vc1.example.com --host-name "esx1.example.com" --memory-usage-warning 80 --memory-usage-critical 95 --trust-cert --log-level info
+```
+
+See the [configuration options](#configuration-options) section for all
+command-line settings supported by this plugin along with descriptions of
+each. See the [contrib](#contrib) section for information regarding example
+command definitions and Nagios configuration files.
+
+Of note:
+
+- The host name is specified (via `host-name` flag) using the exact value
+  shown in the vSphere inventory (e.g., `esx1.example.com`)
+- Certificate warnings are ignored.
+  - not best practice, but many vCenter instances use self-signed certs per
+    various freely available guides
+- Logging is enabled at the `info` level.
+  - this output is sent to `stderr` by default, which Nagios ignores
+  - this output is only seen (at least as of Nagios v3.x) when invoking the
+    plugin directly via CLI (often for troubleshooting)
+
+#### Command definition
+
+```shell
+# /etc/nagios-plugins/config/vmware-host-memory.cfg
+
+# Look at a specific host and explicitly provide custom WARNING and CRITICAL
+# threshold values.
+define command{
+    command_name    check_vmware_host_memory
+    command_line    /usr/lib/nagios/plugins/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    }
+```
 
 ## License
 

--- a/cmd/check_vmware_host_memory/doc.go
+++ b/cmd/check_vmware_host_memory/doc.go
@@ -1,0 +1,27 @@
+/*
+
+Nagios plugin used to monitor ESXi host memory.
+
+PURPOSE
+
+In addition to reporting current host memory usage, this plugin also reports
+which VMs are on the host (running or not), how much memory each VM is using
+as a fixed value and as a percentage of the host's total memory.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -54,6 +54,7 @@ contrib
         │       ├── send2teams.cfg
         │       ├── vmware-datastores.cfg
         │       ├── vmware-host-datastore-vms-pairings.cfg
+        │       ├── vmware-host-memory.cfg
         │       ├── vmware-resource-pools.cfg
         │       ├── vmware-snapshots-age.cfg
         │       ├── vmware-snapshots-count.cfg
@@ -87,7 +88,7 @@ contrib
             ├── nagios.cfg
             └── resource.cfg
 
-13 directories, 27 files
+13 directories, 28 files
 ```
 
 ### Overview

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-host-memory.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-host-memory.cfg
@@ -1,0 +1,14 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Look at a specific host and explicitly provide custom WARNING and CRITICAL
+# threshold values.
+define command{
+    command_name    check_vmware_host_memory
+    command_line    /usr/lib/nagios/plugins/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    }

--- a/contrib/nagios/etc/nagios3/conf/groups/service-groups.cfg
+++ b/contrib/nagios/etc/nagios3/conf/groups/service-groups.cfg
@@ -53,3 +53,8 @@ define servicegroup{
     servicegroup_name   vmware-hs2ds2vms-checks
     alias               VMware Host-Datastore-VMs Pairing Checks
     }
+
+define servicegroup{
+    servicegroup_name   vmware-host-checks
+    alias               VMware Host Checks
+    }

--- a/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
+++ b/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
@@ -119,12 +119,6 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Resource Pools
     servicegroups           vmware-checks, vmware-resource-pool-checks
-    # Virtual machine hosts have a hidden resource pool named 'Resources',
-    # which is a parent of all resource pools of the host. This pool throws
-    # off our calculations, so we explicitly ignore it in the script logic
-    # itself. Because of that, we do NOT have to list it here.
-    # https://code.vmware.com/docs/9638/cmdlet-reference/doc/Get-ResourcePool.html
-    # https://pubs.vmware.com/vsphere-51/topic/com.vmware.powercli.cmdletref.doc/Get-ResourcePool.html
     check_command           check_vmware_resource_pools_include_pools!example!vc1-read-only-service-account!$USER13$!97!99!320!"Desktops", "Server Support"
     # Argument 1: User Domain
     # Argument 2: Service Account username
@@ -133,6 +127,45 @@ define service{
     # Argument 5: Critical memory threshold in percentage, given as whole number
     # Argument 6: Maximum Memory allowed for our use based on leased Virtual Resource Units (VRUs), given as a whole number
     # Argument 7: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
+    service_description     VMware Host Memory - esxi1
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_memory!example!vc1-read-only-service-account!$USER13$!97!99!esx1.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning memory threshold in percentage, given as whole number
+    # Argument 5: Critical memory threshold in percentage, given as whole number
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
+    service_description     VMware Host Memory - esxi2
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_memory!example!vc1-read-only-service-account!$USER13$!97!99!esx2.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning memory threshold in percentage, given as whole number
+    # Argument 5: Critical memory threshold in percentage, given as whole number
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
+    service_description     VMware Host Memory - esxi3
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_memory!example!vc1-read-only-service-account!$USER13$!97!99!esx3.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning memory threshold in percentage, given as whole number
+    # Argument 5: Critical memory threshold in percentage, given as whole number
     }
 
 define service{

--- a/doc.go
+++ b/doc.go
@@ -36,6 +36,8 @@ hosts or vCenter instances) for select (or all) Resource Pools.
 
 • Resource Pools: Memory usage
 
+• Host Memory usage
+
 USAGE
 
 See our main README for supported settings and examples.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,10 @@ type PluginType struct {
 	VirtualCPUsAllocation  bool
 	VirtualHardwareVersion bool
 	Host2Datastores2VMs    bool
+	HostSystemMemory       bool
 
 	// TODO:
-	// - Hosts (memory, CPU usage)
+	// - Hosts (CPU usage)
 	// - vCenter/server time (NTP)
 
 }
@@ -155,6 +156,20 @@ type Config struct {
 	// DatacenterName is the name of a Datacenter in the associated vSphere
 	// inventory. Not applicable to standline ESXi hosts.
 	DatacenterName string
+
+	// HostSystemName is the name of an ESXi host/server in the associated
+	// vSphere inventory.
+	HostSystemName string
+
+	// HostSystemMemoryUseWarning specifies the percentage of memory use (as a
+	// whole number) for the specified ESXi host when a WARNING threshold is
+	// reached.
+	HostSystemMemoryUseWarning int
+
+	// HostSystemMemoryUseCritical specifies the percentage of memory use (as
+	// a whole number) for the specified ESXi host when a CRITICAL threshold
+	// is reached.
+	HostSystemMemoryUseCritical int
 
 	// Port is the TCP port used by the certifcate-enabled service.
 	Port int

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -49,6 +49,9 @@ const (
 	resourcePoolsMemoryMaxAllowedFlagHelp           string = "Specifies the maximum amount of memory that we are allowed to consume in GB (as a whole number) in the target VMware environment across all specified Resource Pools. VMs that are running outside of resource pools are not considered in these calculations."
 	resourcePoolsMemoryUseCriticalFlagHelp          string = "Specifies the percentage of memory use (as a whole number) across all specified Resource Pools when a CRITICAL threshold is reached."
 	resourcePoolsMemoryUseWarningFlagHelp           string = "Specifies the percentage of memory use (as a whole number) across all specified Resource Pools when a WARNING threshold is reached."
+	hostSystemMemoryUseCriticalFlagHelp             string = "Specifies the percentage of memory use (as a whole number) when a CRITICAL threshold is reached."
+	hostSystemMemoryUseWarningFlagHelp              string = "Specifies the percentage of memory use (as a whole number) when a WARNING threshold is reached."
+	hostSystemNameFlagHelp                          string = "ESXi host/server name as it is found within the vSphere inventory."
 )
 
 // Default flag settings if not overridden by user input
@@ -76,8 +79,11 @@ const (
 	defaultSnapshotsCountWarning        int    = 4  // recommended cap is 3-4
 	defaultSnapshotsSizeCritical        int    = 40 // size in GB
 	defaultSnapshotsSizeWarning         int    = 20 // size in GB
-	defaultMemoryUseCritical            int    = 95
-	defaultMemoryUseWarning             int    = 80
+	defaultHostSystemName               string = ""
+
+	// default memory usage values for Resource Pools and ESXi Host systems
+	defaultMemoryUseCritical int = 95
+	defaultMemoryUseWarning  int = 80
 
 	// Intentionally set low to trigger validation failure if not specified by
 	// the end user.
@@ -119,4 +125,5 @@ const (
 	PluginTypeResourcePoolsMemory      string = "resource-pools-memory"
 	PluginTypeVirtualCPUsAllocation    string = "virtual-cpus-allocation"
 	PluginTypeHostDatastoreVMsPairings string = "host-to-ds-to-vms"
+	PluginTypeHostSystemMemory         string = "host-system-memory"
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -100,6 +100,18 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.IntVar(&c.DatastoreUsageCritical, "ds-usage-critical", defaultDatastoreUsageCritical, datastoreUsageCriticalFlagHelp)
 		flag.IntVar(&c.DatastoreUsageCritical, "dsuc", defaultDatastoreUsageCritical, datastoreUsageCriticalFlagHelp+" (shorthand)")
 
+	case pluginType.HostSystemMemory:
+
+		flag.StringVar(&c.DatacenterName, "dc-name", defaultDatacenterName, datacenterNameFlagHelp)
+
+		flag.StringVar(&c.HostSystemName, "host-name", defaultHostSystemName, hostSystemNameFlagHelp)
+
+		flag.IntVar(&c.HostSystemMemoryUseWarning, "memory-usage-warning", defaultMemoryUseWarning, hostSystemMemoryUseWarningFlagHelp)
+		flag.IntVar(&c.HostSystemMemoryUseWarning, "mw", defaultMemoryUseWarning, hostSystemMemoryUseWarningFlagHelp+" (shorthand)")
+
+		flag.IntVar(&c.HostSystemMemoryUseCritical, "memory-usage-critical", defaultMemoryUseCritical, hostSystemMemoryUseCriticalFlagHelp)
+		flag.IntVar(&c.HostSystemMemoryUseCritical, "mc", defaultMemoryUseCritical, hostSystemMemoryUseCriticalFlagHelp+" (shorthand)")
+
 	case pluginType.ResourcePoolsMemory:
 
 		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -119,6 +119,9 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	case pluginType.Host2Datastores2VMs:
 		appDescription = PluginTypeHostDatastoreVMsPairings
 
+	case pluginType.HostSystemMemory:
+		appDescription = PluginTypeHostSystemMemory
+
 	case pluginType.Tools:
 		appDescription = PluginTypeTools
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -130,6 +130,32 @@ func (c Config) validate(pluginType PluginType) error {
 			)
 		}
 
+	case pluginType.HostSystemMemory:
+
+		if c.HostSystemName == "" {
+			return fmt.Errorf("host name not provided")
+		}
+
+		if c.HostSystemMemoryUseCritical < 1 {
+			return fmt.Errorf(
+				"invalid host memory usage (percentage as whole number) CRITICAL threshold number: %d",
+				c.HostSystemMemoryUseCritical,
+			)
+		}
+
+		if c.HostSystemMemoryUseWarning < 1 {
+			return fmt.Errorf(
+				"invalid host memory usage (percentage as whole number) WARNING threshold number: %d",
+				c.HostSystemMemoryUseWarning,
+			)
+		}
+
+		if c.HostSystemMemoryUseCritical < c.HostSystemMemoryUseWarning {
+			return fmt.Errorf(
+				"critical threshold set lower than warning threshold",
+			)
+		}
+
 	case pluginType.ResourcePoolsMemory:
 
 		if c.ResourcePoolsMemoryMaxAllowed < 1 {

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -23,13 +23,9 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// ErrDatastoreUsageCriticalLevel indicates that Datastore usage has crossed
-// the CRITICAL level threshold.
-var ErrDatastoreUsageCriticalLevel = errors.New("datastore usage critical level")
-
-// ErrDatastoreUsageWarningLevel indicates that Datastore usage has crossed
-// the CRITICAL level threshold.
-var ErrDatastoreUsageWarningLevel = errors.New("datastore usage warning level")
+// ErrDatastoreUsageThresholdCrossed indicates that specified
+// resource pools have exceeded a given threshold
+var ErrDatastoreUsageThresholdCrossed = errors.New("datastore usage exceeds specified threshold")
 
 // DatastoreIDToNameIndex maps a Datastore's ID value to its name.
 type DatastoreIDToNameIndex map[string]string


### PR DESCRIPTION
As with several other plugins in this project, this one borrows
heavily from existing projects. In particular, this plugin is based
heavily on the datastore usage plugin while borrowing elements from
other recent plugins. Small adjustments were made to shared code in
order to support the new plugin.

In short, this plugin monitors the memory use on a specified host.
This plugin also reports which powered on and powered off VMs are
attached to the host along with the memory consumed by each, including
the overall percentage of the host's memory.

Doc updates have been applied, example usage has been added, including
a command definition "contrib" file illustrating how the plugin would
be referenced within a production Nagios configuration.

fixes GH-7
