### PR TITLE
Replace GetVMsFromRPs func with shared func

### DIFF
--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/textutils"
@@ -167,7 +168,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -176,7 +177,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -176,7 +177,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -176,7 +177,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -171,7 +172,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -180,7 +181,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/atc0005/go-nagios"
+	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/atc0005/check-vmware/internal/config"
 	"github.com/atc0005/check-vmware/internal/vsphere"
@@ -169,7 +170,11 @@ func main() {
 		Msg("")
 
 	log.Debug().Msg("Retrieving vms from eligible resource pools")
-	vms, getVMsErr := vsphere.GetVMsFromRPs(ctx, c.Client, resourcePools, true)
+	rpEntityVals := make([]mo.ManagedEntity, 0, len(resourcePools))
+	for i := range resourcePools {
+		rpEntityVals = append(rpEntityVals, resourcePools[i].ManagedEntity)
+	}
+	vms, getVMsErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, rpEntityVals...)
 	if getVMsErr != nil {
 		log.Error().Err(getVMsErr).Msg(
 			"error retrieving list of VMs from resource pools list",


### PR DESCRIPTION
This change removes the `GetVMsFromRPs` and uses the `GetVMsFromContainer` func in its place along with a
little leg work to collect `ManagedEntity` values ahead of time.

Not sure if I'll use this approach long term or not (seems to offload complexity back to the "front end").

fixes GH-125
