### PR TITLE
Add initial draft of host cpu monitoring plugin

### DIFF
--- a/.github/workflows/lint-and-build-code.yml
+++ b/.github/workflows/lint-and-build-code.yml
@@ -92,3 +92,4 @@ jobs:
           go build -v -mod=vendor ./cmd/check_vmware_snapshots_size
           go build -v -mod=vendor ./cmd/check_vmware_rps_memory
           go build -v -mod=vendor ./cmd/check_vmware_host_memory
+          go build -v -mod=vendor ./cmd/check_vmware_host_cpu

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ scratch/
 /check_vmware_snapshots_size
 /check_vmware_rps_memory
 /check_vmware_host_memory
+/check_vmware_host_cpu

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ WHAT 					= check_vmware_tools \
 							check_vmware_snapshots_size \
 							check_vmware_rps_memory \
 							check_vmware_host_memory \
+							check_vmware_host_cpu \
 
 
 # What package holds the "version" variable used in branding/version output?

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ or endorsed by VMware, Inc.
     - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size)
     - [`check_vmware_rps_memory`](#check_vmware_rps_memory)
     - [`check_vmware_host_memory`](#check_vmware_host_memory)
+    - [`check_vmware_host_cpu`](#check_vmware_host_cpu)
   - [Features](#features)
   - [Changelog](#changelog)
   - [Requirements](#requirements)
@@ -46,6 +47,7 @@ or endorsed by VMware, Inc.
       - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size-1)
       - [`check_vmware_rps_memory`](#check_vmware_rps_memory-1)
       - [`check_vmware_host_memory`](#check_vmware_host_memory-1)
+      - [`check_vmware_host_cpu`](#check_vmware_host_cpu-1)
     - [Command-line arguments](#command-line-arguments)
       - [`check_vmware_tools`](#check_vmware_tools-2)
       - [`check_vmware_vcpus`](#check_vmware_vcpus-2)
@@ -57,6 +59,7 @@ or endorsed by VMware, Inc.
       - [`check_vmware_snapshots_size`](#check_vmware_snapshots_size-2)
       - [`check_vmware_rps_memory`](#check_vmware_rps_memory-2)
       - [`check_vmware_host_memory`](#check_vmware_host_memory-2)
+      - [`check_vmware_host_cpu`](#check_vmware_host_cpu-2)
     - [Configuration file](#configuration-file)
   - [Contrib](#contrib)
   - [Examples](#examples)
@@ -90,6 +93,9 @@ or endorsed by VMware, Inc.
     - [`check_vmware_host_memory` Nagios plugin](#check_vmware_host_memory-nagios-plugin)
       - [CLI invocation](#cli-invocation-9)
       - [Command definition](#command-definition-9)
+    - [`check_vmware_host_cpu` Nagios plugin](#check_vmware_host_cpu-nagios-plugin)
+      - [CLI invocation](#cli-invocation-10)
+      - [Command definition](#command-definition-10)
   - [License](#license)
   - [References](#references)
 
@@ -118,6 +124,7 @@ This repo contains various tools used to monitor/validate VMware environments.
 | `check_vmware_snapshots_size`  | Alpha  | Nagios plugin used to monitor the **cumulative** size of Virtual Machine snapshots. |
 | `check_vmware_rps_memory`      | Alpha  | Nagios plugin used to monitor memory usage across Resource Pools.                   |
 | `check_vmware_host_memory`     | Alpha  | Nagios plugin used to monitor memory usage for a specific ESXi host system.         |
+| `check_vmware_host_cpu`        | Alpha  | Nagios plugin used to monitor CPU usage for a specific ESXi host system.            |
 
 The output for these plugins is designed to provide the one-line summary
 needed by Nagios for quick identification of a problem while providing longer,
@@ -288,6 +295,18 @@ Thresholds for `CRITICAL` and `WARNING` memory usage have usable defaults, but
 max memory usage is required before this plugin can be used. See the
 [configuration options](#configuration-options) section for details.
 
+### `check_vmware_host_cpu`
+
+Nagios plugin used to monitor ESXi host CPU usage.
+
+In addition to reporting current host CPU usage, this plugin also reports
+which VMs are on the host (running or not), how much CPU each VM is using
+as a fixed value and as a percentage of the host's total CPU capacity.
+
+Thresholds for `CRITICAL` and `WARNING` CPU usage have usable defaults, but
+may require adjustment for your environment. See the [configuration
+options](#configuration-options) section for details.
+
 ## Features
 
 - Multiple plugins for monitoring VMware vSphere environments (standalone ESXi
@@ -302,6 +321,7 @@ max memory usage is required before this plugin can be used. See the
   - Snapshots size
   - Resource Pools: Memory usage
   - Host Memory usage
+  - Host CPU usage
 
 - Optional, leveled logging using `rs/zerolog` package
   - JSON-format output (to `stderr`)
@@ -384,6 +404,7 @@ been tested.
      - `go build -mod=vendor ./cmd/check_vmware_snapshots_size/`
      - `go build -mod=vendor ./cmd/check_vmware_rps_memory/`
      - `go build -mod=vendor ./cmd/check_vmware_host_memory/`
+     - `go build -mod=vendor ./cmd/check_vmware_host_cpu/`
    - for all supported platforms (where `make` is installed)
       - `make all`
    - for use on Windows
@@ -404,6 +425,7 @@ been tested.
      - look in `/tmp/check-vmware/release_assets/check_vmware_snapshots_size/`
      - look in `/tmp/check-vmware/release_assets/check_vmware_rps_memory/`
      - look in `/tmp/check-vmware/release_assets/check_vmware_host_memory/`
+     - look in `/tmp/check-vmware/release_assets/check_vmware_host_cpu/`
    - if using `go build`
      - look in `/tmp/check-vmware/`
 1. Review [configuration options](#configuration-options),
@@ -493,6 +515,14 @@ been tested.
 | `OK`         | Ideal state, memory usage for the specified ESXi host system is within bounds. |
 | `WARNING`    | Memory usage crossed user-specified threshold for this state.                  |
 | `CRITICAL`   | Memory usage crossed user-specified threshold for this state.                  |
+
+#### `check_vmware_host_cpu`
+
+| Nagios State | Description                                                                 |
+| ------------ | --------------------------------------------------------------------------- |
+| `OK`         | Ideal state, CPU usage for the specified ESXi host system is within bounds. |
+| `WARNING`    | CPU usage crossed user-specified threshold for this state.                  |
+| `CRITICAL`   | CPU usage crossed user-specified threshold for this state.                  |
 
 ### Command-line arguments
 
@@ -715,6 +745,26 @@ been tested.
 | `host-name`                   | **Yes**  |         | No     | *valid ESXi host name*                                                  | ESXi host/server name as it is found within the vSphere inventory.                                                                                                                                     |
 | `mc`, `memory-usage-critical` | No       | `95`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) when a CRITICAL threshold is reached.                                                                                                       |
 | `mw`, `memory-usage-warning`  | No       | `80`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of memory use (as a whole number) when a WARNING threshold is reached.                                                                                                        |
+
+#### `check_vmware_host_cpu`
+
+| Flag                       | Required | Default | Repeat | Possible                                                                | Description                                                                                                                                                                                            |
+| -------------------------- | -------- | ------- | ------ | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `branding`                 | No       | `false` | No     | `branding`                                                              | Toggles emission of branding details with plugin status details. This output is disabled by default.                                                                                                   |
+| `h`, `help`                | No       | `false` | No     | `h`, `help`                                                             | Show Help text along with the list of supported flags.                                                                                                                                                 |
+| `v`, `version`             | No       | `false` | No     | `v`, `version`                                                          | Whether to display application version and then immediately exit application.                                                                                                                          |
+| `ll`, `log-level`          | No       | `info`  | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Log message priority filter. Log messages with a lower level are ignored.                                                                                                                              |
+| `p`, `port`                | No       | `443`   | No     | *positive whole number between 1-65535, inclusive*                      | TCP port of the remote ESXi host or vCenter instance. This is usually 443 (HTTPS).                                                                                                                     |
+| `t`, `timeout`             | No       | `10`    | No     | *positive whole number of seconds*                                      | Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned.                                                                                                 |
+| `s`, `server`              | **Yes**  |         | No     | *fully-qualified domain name or IP Address*                             | The fully-qualified domain name or IP Address of the remote ESXi host or vCenter instance.                                                                                                             |
+| `u`, `username`            | **Yes**  |         | No     | *valid username*                                                        | Username with permission to access specified ESXi host or vCenter instance.                                                                                                                            |
+| `pw`, `password`           | **Yes**  |         | No     | *valid password*                                                        | Password used to login to ESXi host or vCenter instance.                                                                                                                                               |
+| `domain`                   | No       |         | No     | *valid user domain*                                                     | (Optional) domain for user account used to login to ESXi host or vCenter instance.                                                                                                                     |
+| `trust-cert`               | No       | `false` | No     | `true`, `false`                                                         | Whether the certificate should be trusted as-is without validation. WARNING: TLS is susceptible to man-in-the-middle attacks if enabling this option.                                                  |
+| `dc-name`                  | No       |         | No     | *valid vSphere datacenter name*                                         | Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts. |
+| `host-name`                | **Yes**  |         | No     | *valid ESXi host name*                                                  | ESXi host/server name as it is found within the vSphere inventory.                                                                                                                                     |
+| `cc`, `cpu-usage-critical` | No       | `95`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of CPU use (as a whole number) when a CRITICAL threshold is reached.                                                                                                          |
+| `cw`, `cpu-usage-warning`  | No       | `80`    | No     | *percentage as positive whole number*                                   | Specifies the percentage of CPU use (as a whole number) when a WARNING threshold is reached.                                                                                                           |
 
 ### Configuration file
 
@@ -1219,6 +1269,44 @@ Of note:
 define command{
     command_name    check_vmware_host_memory
     command_line    /usr/lib/nagios/plugins/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    }
+```
+
+### `check_vmware_host_cpu` Nagios plugin
+
+#### CLI invocation
+
+```ShellSession
+/usr/lib/nagios/plugins/check_vmware_host_cpu --username SERVICE_ACCOUNT_NAME --password "SERVICE_ACCOUNT_PASSWORD" --server vc1.example.com --host-name "esx1.example.com" --cpu-usage-warning 80 --cpu-usage-critical 95 --trust-cert --log-level info
+```
+
+See the [configuration options](#configuration-options) section for all
+command-line settings supported by this plugin along with descriptions of
+each. See the [contrib](#contrib) section for information regarding example
+command definitions and Nagios configuration files.
+
+Of note:
+
+- The host name is specified (via `host-name` flag) using the exact value
+  shown in the vSphere inventory (e.g., `esx1.example.com`)
+- Certificate warnings are ignored.
+  - not best practice, but many vCenter instances use self-signed certs per
+    various freely available guides
+- Logging is enabled at the `info` level.
+  - this output is sent to `stderr` by default, which Nagios ignores
+  - this output is only seen (at least as of Nagios v3.x) when invoking the
+    plugin directly via CLI (often for troubleshooting)
+
+#### Command definition
+
+```shell
+# /etc/nagios-plugins/config/vmware-host-cpu.cfg
+
+# Look at a specific host and explicitly provide custom WARNING and CRITICAL
+# threshold values.
+define command{
+    command_name    check_vmware_host_cpu
+    command_line    /usr/lib/nagios/plugins/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
     }
 ```
 

--- a/cmd/check_vmware_host_cpu/doc.go
+++ b/cmd/check_vmware_host_cpu/doc.go
@@ -1,0 +1,27 @@
+/*
+
+Nagios plugin used to monitor ESXi host CPU usage.
+
+PURPOSE
+
+In addition to reporting current host CPU usage, this plugin also reports
+which VMs are on the host (running or not), how much CPU each VM is using as a
+fixed value and as a percentage of the host's total CPU capacity.
+
+The output for this plugin is designed to provide the one-line summary needed
+by Nagios for quick identification of a problem while providing longer, more
+detailed information for use in email and Teams notifications
+(https://github.com/atc0005/send2teams).
+
+PROJECT HOME
+
+See our GitHub repo (https://github.com/atc0005/check-vmware) for the latest
+code, to file an issue or submit improvements for review and potential
+inclusion into the project.
+
+USAGE
+
+See our main README for supported settings and examples.
+
+*/
+package main

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -53,6 +53,7 @@ contrib
         │   └── config
         │       ├── send2teams.cfg
         │       ├── vmware-datastores.cfg
+        │       ├── vmware-host-cpu.cfg
         │       ├── vmware-host-datastore-vms-pairings.cfg
         │       ├── vmware-host-memory.cfg
         │       ├── vmware-resource-pools.cfg
@@ -88,7 +89,7 @@ contrib
             ├── nagios.cfg
             └── resource.cfg
 
-13 directories, 28 files
+13 directories, 29 files
 ```
 
 ### Overview

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-host-cpu.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-host-cpu.cfg
@@ -1,0 +1,14 @@
+# Copyright 2021 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Look at a specific host and explicitly provide custom WARNING and CRITICAL
+# threshold values.
+define command{
+    command_name    check_vmware_host_cpu
+    command_line    /usr/lib/nagios/plugins/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    }

--- a/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
+++ b/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
@@ -171,6 +171,45 @@ define service{
 define service{
     use                     vmware-vsphere-service
     host_name               vc1.exmaple.com
+    service_description     VMware Host CPU - esxi1
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_cpu!example!vc1-read-only-service-account!$USER13$!87!95!esx1.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning CPU threshold in percentage, given as whole number
+    # Argument 5: Critical CPU threshold in percentage, given as whole number
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
+    service_description     VMware Host CPU - esxi2
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_cpu!example!vc1-read-only-service-account!$USER13$!87!95!esx2.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning CPU threshold in percentage, given as whole number
+    # Argument 5: Critical CPU threshold in percentage, given as whole number
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
+    service_description     VMware Host CPU - esxi3
+    servicegroups           vmware-checks, vmware-host-checks
+    check_command           check_vmware_host_cpu!example!vc1-read-only-service-account!$USER13$!87!95!esx3.example.com
+    # Argument 1: User Domain
+    # Argument 2: Service Account username
+    # Argument 3: Service Account password (see resource.cfg)
+    # Argument 4: Warning CPU threshold in percentage, given as whole number
+    # Argument 5: Critical CPU threshold in percentage, given as whole number
+    }
+
+define service{
+    use                     vmware-vsphere-service
+    host_name               vc1.exmaple.com
     service_description     VMware Datastore - HUSVM-DC1-vol6
     servicegroups           vmware-checks, vmware-datastore-checks
     check_command           check_vmware_datastore!example!vc1-read-only-service-account!$USER13$!90!95!HUSVM-DC1-vol6

--- a/doc.go
+++ b/doc.go
@@ -38,6 +38,8 @@ hosts or vCenter instances) for select (or all) Resource Pools.
 
 • Host Memory usage
 
+• Host CPU usage
+
 USAGE
 
 See our main README for supported settings and examples.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,9 +42,9 @@ type PluginType struct {
 	VirtualHardwareVersion bool
 	Host2Datastores2VMs    bool
 	HostSystemMemory       bool
+	HostSystemCPU          bool
 
 	// TODO:
-	// - Hosts (CPU usage)
 	// - vCenter/server time (NTP)
 
 }
@@ -170,6 +170,16 @@ type Config struct {
 	// a whole number) for the specified ESXi host when a CRITICAL threshold
 	// is reached.
 	HostSystemMemoryUseCritical int
+
+	// HostSystemCPUUseWarning specifies the percentage of CPU use (as a whole
+	// number) for the specified ESXi host when a WARNING threshold is
+	// reached.
+	HostSystemCPUUseWarning int
+
+	// HostSystemCPUUseCritical specifies the percentage of CPU use (as a
+	// whole number) for the specified ESXi host when a CRITICAL threshold is
+	// reached.
+	HostSystemCPUUseCritical int
 
 	// Port is the TCP port used by the certifcate-enabled service.
 	Port int

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -52,6 +52,8 @@ const (
 	hostSystemMemoryUseCriticalFlagHelp             string = "Specifies the percentage of memory use (as a whole number) when a CRITICAL threshold is reached."
 	hostSystemMemoryUseWarningFlagHelp              string = "Specifies the percentage of memory use (as a whole number) when a WARNING threshold is reached."
 	hostSystemNameFlagHelp                          string = "ESXi host/server name as it is found within the vSphere inventory."
+	hostSystemCPUUseCriticalFlagHelp                string = "Specifies the percentage of CPU use (as a whole number) when a CRITICAL threshold is reached."
+	hostSystemCPUUseWarningFlagHelp                 string = "Specifies the percentage of CPU use (as a whole number) when a WARNING threshold is reached."
 )
 
 // Default flag settings if not overridden by user input
@@ -84,6 +86,10 @@ const (
 	// default memory usage values for Resource Pools and ESXi Host systems
 	defaultMemoryUseCritical int = 95
 	defaultMemoryUseWarning  int = 80
+
+	// HostSystem CPU usage thresholds
+	defaultCPUUseCritical int = 95
+	defaultCPUUseWarning  int = 80
 
 	// Intentionally set low to trigger validation failure if not specified by
 	// the end user.
@@ -126,4 +132,5 @@ const (
 	PluginTypeVirtualCPUsAllocation    string = "virtual-cpus-allocation"
 	PluginTypeHostDatastoreVMsPairings string = "host-to-ds-to-vms"
 	PluginTypeHostSystemMemory         string = "host-system-memory"
+	PluginTypeHostSystemCPU            string = "host-system-cpu"
 )

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -112,6 +112,18 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.IntVar(&c.HostSystemMemoryUseCritical, "memory-usage-critical", defaultMemoryUseCritical, hostSystemMemoryUseCriticalFlagHelp)
 		flag.IntVar(&c.HostSystemMemoryUseCritical, "mc", defaultMemoryUseCritical, hostSystemMemoryUseCriticalFlagHelp+" (shorthand)")
 
+	case pluginType.HostSystemCPU:
+
+		flag.StringVar(&c.DatacenterName, "dc-name", defaultDatacenterName, datacenterNameFlagHelp)
+
+		flag.StringVar(&c.HostSystemName, "host-name", defaultHostSystemName, hostSystemNameFlagHelp)
+
+		flag.IntVar(&c.HostSystemCPUUseWarning, "cpu-usage-warning", defaultCPUUseWarning, hostSystemCPUUseWarningFlagHelp)
+		flag.IntVar(&c.HostSystemCPUUseWarning, "cw", defaultCPUUseWarning, hostSystemCPUUseWarningFlagHelp+" (shorthand)")
+
+		flag.IntVar(&c.HostSystemCPUUseCritical, "cpu-usage-critical", defaultCPUUseCritical, hostSystemCPUUseCriticalFlagHelp)
+		flag.IntVar(&c.HostSystemCPUUseCritical, "cc", defaultCPUUseCritical, hostSystemCPUUseCriticalFlagHelp+" (shorthand)")
+
 	case pluginType.ResourcePoolsMemory:
 
 		flag.Var(&c.IncludedResourcePools, "include-rp", includedResourcePoolsFlagHelp)

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -122,6 +122,9 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	case pluginType.HostSystemMemory:
 		appDescription = PluginTypeHostSystemMemory
 
+	case pluginType.HostSystemCPU:
+		appDescription = PluginTypeHostSystemCPU
+
 	case pluginType.Tools:
 		appDescription = PluginTypeTools
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -156,6 +156,32 @@ func (c Config) validate(pluginType PluginType) error {
 			)
 		}
 
+	case pluginType.HostSystemCPU:
+
+		if c.HostSystemName == "" {
+			return fmt.Errorf("host name not provided")
+		}
+
+		if c.HostSystemCPUUseCritical < 1 {
+			return fmt.Errorf(
+				"invalid host CPU usage (percentage as whole number) CRITICAL threshold number: %d",
+				c.HostSystemCPUUseCritical,
+			)
+		}
+
+		if c.HostSystemCPUUseWarning < 1 {
+			return fmt.Errorf(
+				"invalid host CPU usage (percentage as whole number) WARNING threshold number: %d",
+				c.HostSystemCPUUseWarning,
+			)
+		}
+
+		if c.HostSystemCPUUseCritical < c.HostSystemCPUUseWarning {
+			return fmt.Errorf(
+				"critical threshold set lower than warning threshold",
+			)
+		}
+
 	case pluginType.ResourcePoolsMemory:
 
 		if c.ResourcePoolsMemoryMaxAllowed < 1 {

--- a/internal/vsphere/cpu.go
+++ b/internal/vsphere/cpu.go
@@ -1,0 +1,62 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package vsphere
+
+import "fmt"
+
+// CPUSpeed represents the speed of a CPU
+type CPUSpeed float64
+
+// CPU speed values
+const (
+
+	// https://stackoverflow.com/questions/34124294/writing-powers-of-10-as-constants-compactly
+	// untyped float
+	Hz  = 1
+	KHz = 1e3
+	MHz = 1e6
+	GHz = 1e9
+	THz = 1e12
+	PHz = 1e15
+	EHz = 1e18
+	ZHz = 1e21
+	YHz = 1e24
+
+	// untyped int
+	// Hz  = 1
+	// KHz = Hz * 1000
+	// MHz = KHz * 1000
+	// GHz = MHz * 1000
+	// THz = GHz * 1000
+	// PHz = THz * 1000
+	// EHz = PHz * 1000
+	// ZHz = EHz * 1000
+	// YHz = ZHz * 1000
+)
+
+func (cpu CPUSpeed) String() string {
+	switch {
+	case cpu >= YHz:
+		return fmt.Sprintf("%.1f EHz", float64(cpu)/YHz)
+	case cpu >= ZHz:
+		return fmt.Sprintf("%.1f EHz", float64(cpu)/ZHz)
+	case cpu >= EHz:
+		return fmt.Sprintf("%.1f EHz", float64(cpu)/EHz)
+	case cpu >= PHz:
+		return fmt.Sprintf("%.1f PHz", float64(cpu)/PHz)
+	case cpu >= THz:
+		return fmt.Sprintf("%.1f THz", float64(cpu)/THz)
+	case cpu >= GHz:
+		return fmt.Sprintf("%.1f GHz", float64(cpu)/GHz)
+	case cpu >= MHz:
+		return fmt.Sprintf("%.1f MHz", float64(cpu)/MHz)
+	case cpu >= KHz:
+		return fmt.Sprintf("%.1f KHz", float64(cpu)/KHz)
+	}
+	return fmt.Sprintf("%d Hz", int(cpu))
+}


### PR DESCRIPTION
This plugin is based heavily on the existing host memory monitoring
plugin. Small adjustments were made to shared code in
order to support the new plugin.

In short, this plugin monitors the CPU usage on a specified host.
This plugin also reports which powered on and powered off VMs are
attached to the host along with the CPU consumed by each, including
the overall percentage of the host's CPU capacity.

Doc updates have been applied, example usage has been added, including
a command definition "contrib" file illustrating how the plugin would
be referenced within a production Nagios configuration.

fixes GH-13