### PR TITLE
Update CI Makefile-drive builds timeout

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -56,7 +56,7 @@ jobs:
     name: Build codebase using Makefile
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 20
+    timeout-minutes: 40
     container:
       image: "index.docker.io/golang:latest"
 


### PR DESCRIPTION
Bump from 20 to 40 minutes.

fixes GH-138