### PR TITLE
Refactor VM power cycle uptime OK results sampling

### DIFF
--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -212,15 +212,9 @@ func main() {
 
 	// here we diverge from other plugins
 
-	log.Debug().Msg("Filter VMs to those which cross power cycle uptime thresholds")
-	vmsWithHighUptime := vsphere.FilterVMsByPowerCycleUptime(
-		filteredVMs,
-		cfg.VMPowerCycleUptimeWarning,
-		cfg.VMPowerCycleUptimeCritical,
-	)
-
+	log.Debug().Msg("Generate VM power cycle uptime summary")
 	uptimeSummary := vsphere.GetVMPowerCycleUptimeStatusSummary(
-		vmsWithHighUptime,
+		filteredVMs,
 		cfg.VMPowerCycleUptimeWarning,
 		cfg.VMPowerCycleUptimeCritical,
 	)


### PR DESCRIPTION
- Extend `VirtualMachinePowerCycleUptimeStatus` to store
  VMs not yet exceeding threhsolds for later reference

- Add `TopTenOK` method to retrieve the top ten VMs with
  power cycle uptime not yet exceeding thresholds

- Update `GetVMPowerCycleUptimeStatusSummary` func to
  record VMs not yet exceeding threhsold

- Update main plugin code to no longer pre-filter VMs
  to just those with high uptime, instead letting the
  `GetVMPowerCycleUptimeStatusSummary` func handle
  that task

refs GH-140