### PR TITLE
Fix BottomTenOK method

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -106,7 +106,7 @@ func (vpcs VirtualMachinePowerCycleUptimeStatus) BottomTenOK() []mo.VirtualMachi
 	}
 
 	bottomTen := make([]mo.VirtualMachine, 0, sampleSize)
-	bottomTen = append(bottomTen, vpcs.VMsOK[:sampleSize]...)
+	bottomTen = append(bottomTen, poweredOnVMs[:sampleSize]...)
 
 	return bottomTen
 


### PR DESCRIPTION
This change was meant to be included in commit 180b8b29deb4d915dd35fe0840074875d5bb3655, but git stash
grabbed the change along with other loosely related modifications.

refs GH-152