### PR TITLE
Extend check vhw plugin to support default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ or endorsed by VMware, Inc.
       - [Homogeneous version check](#homogeneous-version-check)
       - [Outdated-by or threshold range check](#outdated-by-or-threshold-range-check)
       - [Minimum required version check](#minimum-required-version-check)
+      - [Default is minimum required version check](#default-is-minimum-required-version-check)
     - [`check_vmware_hs2ds2vms`](#check_vmware_hs2ds2vms)
     - [`check_vmware_datastore`](#check_vmware_datastore)
     - [`check_vmware_snapshots_age`](#check_vmware_snapshots_age)
@@ -47,6 +48,7 @@ or endorsed by VMware, Inc.
         - [Homogeneous version check](#homogeneous-version-check-1)
         - [Outdated-by or threshold range check](#outdated-by-or-threshold-range-check-1)
         - [Minimum required version check](#minimum-required-version-check-1)
+        - [Default is minimum required version check](#default-is-minimum-required-version-check-1)
       - [`check_vmware_hs2ds2vms`](#check_vmware_hs2ds2vms-1)
       - [`check_vmware_datastore`](#check_vmware_datastore-1)
       - [`check_vmware_snapshots_age`](#check_vmware_snapshots_age-1)
@@ -88,33 +90,36 @@ or endorsed by VMware, Inc.
       - [Minimum required version check](#minimum-required-version-check-2)
         - [CLI invocation](#cli-invocation-4)
         - [Command definition](#command-definition-4)
+      - [Default is minimum required version check](#default-is-minimum-required-version-check-2)
+        - [CLI invocation](#cli-invocation-5)
+        - [Command definition](#command-definition-5)
     - [`check_vmware_hs2ds2vms` Nagios plugin](#check_vmware_hs2ds2vms-nagios-plugin)
-      - [CLI invocation](#cli-invocation-5)
-      - [Command definition](#command-definition-5)
-    - [`check_vmware_datastore` Nagios plugin](#check_vmware_datastore-nagios-plugin)
       - [CLI invocation](#cli-invocation-6)
       - [Command definition](#command-definition-6)
-    - [`check_vmware_snapshots_age` Nagios plugin](#check_vmware_snapshots_age-nagios-plugin)
+    - [`check_vmware_datastore` Nagios plugin](#check_vmware_datastore-nagios-plugin)
       - [CLI invocation](#cli-invocation-7)
       - [Command definition](#command-definition-7)
-    - [`check_vmware_snapshots_count` Nagios plugin](#check_vmware_snapshots_count-nagios-plugin)
+    - [`check_vmware_snapshots_age` Nagios plugin](#check_vmware_snapshots_age-nagios-plugin)
       - [CLI invocation](#cli-invocation-8)
       - [Command definition](#command-definition-8)
-    - [`check_vmware_snapshots_size` Nagios plugin](#check_vmware_snapshots_size-nagios-plugin)
+    - [`check_vmware_snapshots_count` Nagios plugin](#check_vmware_snapshots_count-nagios-plugin)
       - [CLI invocation](#cli-invocation-9)
       - [Command definition](#command-definition-9)
-    - [`check_vmware_rps_memory` Nagios plugin](#check_vmware_rps_memory-nagios-plugin)
+    - [`check_vmware_snapshots_size` Nagios plugin](#check_vmware_snapshots_size-nagios-plugin)
       - [CLI invocation](#cli-invocation-10)
       - [Command definition](#command-definition-10)
-    - [`check_vmware_host_memory` Nagios plugin](#check_vmware_host_memory-nagios-plugin)
+    - [`check_vmware_rps_memory` Nagios plugin](#check_vmware_rps_memory-nagios-plugin)
       - [CLI invocation](#cli-invocation-11)
       - [Command definition](#command-definition-11)
-    - [`check_vmware_host_cpu` Nagios plugin](#check_vmware_host_cpu-nagios-plugin)
+    - [`check_vmware_host_memory` Nagios plugin](#check_vmware_host_memory-nagios-plugin)
       - [CLI invocation](#cli-invocation-12)
       - [Command definition](#command-definition-12)
-    - [`check_vmware_vm_power_uptime` Nagios plugin](#check_vmware_vm_power_uptime-nagios-plugin)
+    - [`check_vmware_host_cpu` Nagios plugin](#check_vmware_host_cpu-nagios-plugin)
       - [CLI invocation](#cli-invocation-13)
       - [Command definition](#command-definition-13)
+    - [`check_vmware_vm_power_uptime` Nagios plugin](#check_vmware_vm_power_uptime-nagios-plugin)
+      - [CLI invocation](#cli-invocation-14)
+      - [Command definition](#command-definition-14)
   - [License](#license)
   - [References](#references)
 
@@ -174,11 +179,12 @@ but Max vCPUs allocation is required before this plugin can be used. See the
 
 Nagios plugin used to monitor virtual hardware versions.
 
-This plugin supports three monitoring modes:
+This plugin supports four monitoring modes:
 
 1. Homogeneous version check
-1. Minimum required version check
 1. Outdated-by or threshold range check
+1. Minimum required version check
+1. Default is minimum required version check
 
 #### Homogeneous version check
 
@@ -215,6 +221,14 @@ This mode was implemented as part of
 all hardware versions match or exceed the specified minimum hardware version.
 This monitoring mode assumes that any deviation is considered a `CRITICAL`
 state.
+
+#### Default is minimum required version check
+
+This mode was implemented as part of
+[GH-130](https://github.com/atc0005/check-vmware/issues/130) and requires that
+all hardware versions match or exceed the host or cluster default hardware
+version. This monitoring mode assumes that any deviation is considered a
+`WARNING` state.
 
 ### `check_vmware_hs2ds2vms`
 
@@ -389,6 +403,7 @@ options](#configuration-options) section for details.
     - homogeneous version check
     - outdated-by or threshold range check
     - minimum required version check
+    - default is minimum required version check
   - Host/Datastore/Virtual Machine pairings (using provided Custom Attribute)
   - Datastore usage
   - Snapshots age
@@ -559,6 +574,14 @@ logic for determining plugin state.
 | `WARNING`    | Not used by this monitoring mode.                                 |
 | `CRITICAL`   | Hardware versions older than the minimum specified value present. |
 
+##### Default is minimum required version check
+
+| Nagios State | Description                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| `OK`         | Ideal state, hardware versions within tolerance.                        |
+| `WARNING`    | Hardware versions older than the host or cluster default value present. |
+| `CRITICAL`   | Not used by this monitoring mode.                                       |
+
 #### `check_vmware_hs2ds2vms`
 
 | Nagios State | Description                                                                  |
@@ -688,26 +711,30 @@ are incompatible with the others. As of this writing these monitoring modes
 are *not* implemented as subcommands, though this may change in the future
 based on feedback.
 
-| Flag                          | Required  | Default | Repeat | Possible                                                                | Description                                                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------------------- | --------- | ------- | ------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `branding`                    | No        | `false` | No     | `branding`                                                              | Toggles emission of branding details with plugin status details. This output is disabled by default.                                                                                                                                                                                                                                                                                          |
-| `h`, `help`                   | No        | `false` | No     | `h`, `help`                                                             | Show Help text along with the list of supported flags.                                                                                                                                                                                                                                                                                                                                        |
-| `v`, `version`                | No        | `false` | No     | `v`, `version`                                                          | Whether to display application version and then immediately exit application.                                                                                                                                                                                                                                                                                                                 |
-| `ll`, `log-level`             | No        | `info`  | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Log message priority filter. Log messages with a lower level are ignored.                                                                                                                                                                                                                                                                                                                     |
-| `p`, `port`                   | No        | `443`   | No     | *positive whole number between 1-65535, inclusive*                      | TCP port of the remote ESXi host or vCenter instance. This is usually 443 (HTTPS).                                                                                                                                                                                                                                                                                                            |
-| `t`, `timeout`                | No        | `10`    | No     | *positive whole number of seconds*                                      | Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned.                                                                                                                                                                                                                                                                                        |
-| `s`, `server`                 | **Yes**   |         | No     | *fully-qualified domain name or IP Address*                             | The fully-qualified domain name or IP Address of the remote ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                    |
-| `u`, `username`               | **Yes**   |         | No     | *valid username*                                                        | Username with permission to access specified ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                                   |
-| `pw`, `password`              | **Yes**   |         | No     | *valid password*                                                        | Password used to login to ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                                                      |
-| `domain`                      | No        |         | No     | *valid user domain*                                                     | (Optional) domain for user account used to login to ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                            |
-| `trust-cert`                  | No        | `false` | No     | `true`, `false`                                                         | Whether the certificate should be trusted as-is without validation. WARNING: TLS is susceptible to man-in-the-middle attacks if enabling this option.                                                                                                                                                                                                                                         |
-| `include-rp`                  | No        |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be exclusively used when evaluating VMs. Specifying this option will also exclude any VMs from evaluation that are *outside* of a Resource Pool. This option is incompatible with specifying a list of Resource Pools to ignore or exclude from evaluation.                                                                    |
-| `exclude-rp`                  | No        |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be ignored when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to include for evaluation.                                                                                                                                                                                                |
-| `ignore-vm`                   | No        |         | No     | *comma-separated list of (vSphere) virtual machine names*               | Specifies a comma-separated list of VM names that should be ignored or excluded from evaluation.                                                                                                                                                                                                                                                                                              |
-| `powered-off`                 | No        | `false` | No     | `true`, `false`                                                         | Toggles evaluation of powered off VMs in addition to powered on VMs. Evaluation of powered off VMs is disabled by default.                                                                                                                                                                                                                                                                    |
-| `obw`, `outdated-by-warning`  | **Maybe** |         | No     | *positive whole number 1 or greater*                                    | If provided, this value is the WARNING threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a WARNING state is triggered. Required if specifying the CRITICAL threshold for outdated virtual hardware versions, incompatible with the minimum required version flag.  |
-| `obw`, `outdated-by-critical` | **Maybe** |         | No     | *positive whole number 1 or greater*                                    | If provided, this value is the CRITICAL threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a CRITICAL state is triggered. Required if specifying the WARNING threshold for outdated virtual hardware versions, incompatible with the minimum required version flag. |
-| `mv`, `minimum-version`       | **Maybe** |         | No     | *positive whole number greater than 3*                                  | If provided, this value is the minimum virtual hardware version accepted for each Virtual Machine. Any Virtual Machine not meeting this minimum value is considered to be in a CRITICAL state. Per [KB 1003746](https://kb.vmware.com/s/article/1003746), version 3 appears to be the oldest version supported. Incompatible with the CRITICAL and WARNING threshold flags.                   |
+| Flag                             | Required  | Default | Repeat | Possible                                                                | Description                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------- | --------- | ------- | ------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `branding`                       | No        | `false` | No     | `branding`                                                              | Toggles emission of branding details with plugin status details. This output is disabled by default.                                                                                                                                                                                                                                                                                          |
+| `h`, `help`                      | No        | `false` | No     | `h`, `help`                                                             | Show Help text along with the list of supported flags.                                                                                                                                                                                                                                                                                                                                        |
+| `v`, `version`                   | No        | `false` | No     | `v`, `version`                                                          | Whether to display application version and then immediately exit application.                                                                                                                                                                                                                                                                                                                 |
+| `ll`, `log-level`                | No        | `info`  | No     | `disabled`, `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` | Log message priority filter. Log messages with a lower level are ignored.                                                                                                                                                                                                                                                                                                                     |
+| `p`, `port`                      | No        | `443`   | No     | *positive whole number between 1-65535, inclusive*                      | TCP port of the remote ESXi host or vCenter instance. This is usually 443 (HTTPS).                                                                                                                                                                                                                                                                                                            |
+| `t`, `timeout`                   | No        | `10`    | No     | *positive whole number of seconds*                                      | Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned.                                                                                                                                                                                                                                                                                        |
+| `s`, `server`                    | **Yes**   |         | No     | *fully-qualified domain name or IP Address*                             | The fully-qualified domain name or IP Address of the remote ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                    |
+| `u`, `username`                  | **Yes**   |         | No     | *valid username*                                                        | Username with permission to access specified ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                                   |
+| `pw`, `password`                 | **Yes**   |         | No     | *valid password*                                                        | Password used to login to ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                                                      |
+| `domain`                         | No        |         | No     | *valid user domain*                                                     | (Optional) domain for user account used to login to ESXi host or vCenter instance.                                                                                                                                                                                                                                                                                                            |
+| `trust-cert`                     | No        | `false` | No     | `true`, `false`                                                         | Whether the certificate should be trusted as-is without validation. WARNING: TLS is susceptible to man-in-the-middle attacks if enabling this option.                                                                                                                                                                                                                                         |
+| `dc-name`                        | No        |         | No     | *valid vSphere datacenter name*                                         | Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts.                                                                                                                                                                                        |
+| `host-name`                      | No        |         | No     | *valid ESXi host name*                                                  | ESXi host/server name as it is found within the vSphere inventory.                                                                                                                                                                                                                                                                                                                            |
+| `cluster-name`                   | No        |         | No     | *valid vSphere cluster name*                                            | Specifies the name of a vSphere Cluster. If not specified, applicable plugins will attempt to use the default cluster found in the vSphere environment. Not applicable to standalone ESXi hosts.                                                                                                                                                                                              |
+| `include-rp`                     | No        |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be exclusively used when evaluating VMs. Specifying this option will also exclude any VMs from evaluation that are *outside* of a Resource Pool. This option is incompatible with specifying a list of Resource Pools to ignore or exclude from evaluation.                                                                    |
+| `exclude-rp`                     | No        |         | No     | *comma-separated list of resource pool names*                           | Specifies a comma-separated list of Resource Pools that should be ignored when evaluating VMs. This option is incompatible with specifying a list of Resource Pools to include for evaluation.                                                                                                                                                                                                |
+| `ignore-vm`                      | No        |         | No     | *comma-separated list of (vSphere) virtual machine names*               | Specifies a comma-separated list of VM names that should be ignored or excluded from evaluation.                                                                                                                                                                                                                                                                                              |
+| `powered-off`                    | No        | `false` | No     | `true`, `false`                                                         | Toggles evaluation of powered off VMs in addition to powered on VMs. Evaluation of powered off VMs is disabled by default.                                                                                                                                                                                                                                                                    |
+| `obw`, `outdated-by-warning`     | **Maybe** |         | No     | *positive whole number 1 or greater*                                    | If provided, this value is the WARNING threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a WARNING state is triggered. Required if specifying the CRITICAL threshold for outdated virtual hardware versions, incompatible with the minimum required version flag.  |
+| `obw`, `outdated-by-critical`    | **Maybe** |         | No     | *positive whole number 1 or greater*                                    | If provided, this value is the CRITICAL threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a CRITICAL state is triggered. Required if specifying the WARNING threshold for outdated virtual hardware versions, incompatible with the minimum required version flag. |
+| `mv`, `minimum-version`          | **Maybe** |         | No     | *positive whole number greater than 3*                                  | If provided, this value is the minimum virtual hardware version accepted for each Virtual Machine. Any Virtual Machine not meeting this minimum value is considered to be in a CRITICAL state. Per [KB 1003746](https://kb.vmware.com/s/article/1003746), version 3 appears to be the oldest version supported. Incompatible with the CRITICAL and WARNING threshold flags.                   |
+| `dimv`, `default-is-min-version` | **Maybe** |         | No     | *positive whole number greater than 3*                                  | If provided, this value is the minimum virtual hardware version accepted for each Virtual Machine. Any Virtual Machine not meeting this minimum value is considered to be in a CRITICAL state. Per [KB 1003746](https://kb.vmware.com/s/article/1003746), version 3 appears to be the oldest version supported. Incompatible with the CRITICAL and WARNING threshold flags.                   |
 
 #### `check_vmware_hs2ds2vms`
 
@@ -1032,7 +1059,7 @@ command definitions and Nagios configuration files.
 
 ### `check_vmware_vhw` Nagios plugin
 
-This plugin supports three monitoring modes. Each is incompatible with the
+This plugin supports four monitoring modes. Each is incompatible with the
 other, so an example is provided for each mode. See the [overview](#overview)
 section for further information.
 
@@ -1192,8 +1219,68 @@ Of note:
 # This variation of the command is most useful for environments where all VMs
 # are monitored equally.
 define command{
-    command_name    check_vmware_vhw_thresholds
+    command_name    check_vmware_vhw_minreq
     command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --trust-cert --log-level info
+    }
+
+```
+
+See the [configuration options](#configuration-options) section for all
+command-line settings supported by this plugin along with descriptions of
+each. See the [contrib](#contrib) section for information regarding example
+command definitions and Nagios configuration files.
+
+#### Default is minimum required version check
+
+##### CLI invocation
+
+```ShellSession
+/usr/lib/nagios/plugins/check_vmware_vhw --username SERVICE_ACCOUNT_NAME --password "SERVICE_ACCOUNT_PASSWORD" --server vc1.example.com --exclude-rp "Desktops" --ignore-vm "test1.example.com,redmine.example.com,TESTING-AC,RHEL7-TEST" --default-is-min-version --trust-cert --log-level info
+```
+
+See the [configuration options](#configuration-options) section for all
+command-line settings supported by this plugin along with descriptions of
+each. See the [contrib](#contrib) section for information regarding example
+command definitions and Nagios configuration files.
+
+Of note:
+
+- The default host or cluster hardware version is required
+  - while newer versions are permitted, older versions will trigger a plugin
+    state change.
+- Neither a host name nor a cluster name is provided
+  - the plugin will attempt to use the default `ComputeResource` in order to
+    determine the default hardware version
+- The resource pool named `Desktops` is excluded from evaluation.
+  - this results in *all other* resource pools visible to the specified user
+    account being used for evaluation
+  - this also results in *all* VMs *outside* of a Resource Pool visible to the
+    specified user account being used for evaluation
+- Multiple Virtual machines (vSphere inventory name, not OS hostname), are
+  ignored, regardless of which Resource Pool they are part of.
+  - `test1.example.com`
+  - `redmine.example.com`
+  - `TESTING-AC`
+  - `RHEL7-TEST`
+- Certificate warnings are ignored.
+  - not best practice, but many vCenter instances use self-signed certs per
+    various freely available guides
+- Logging is enabled at the `info` level.
+  - this output is sent to `stderr` by default, which Nagios ignores
+  - this output is only seen (at least as of Nagios v3.x) when invoking the
+    plugin directly via CLI (often for troubleshooting)
+
+##### Command definition
+
+```shell
+# /etc/nagios-plugins/config/vmware-virtual-hardware.cfg
+
+# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally.
+define command{
+    command_name    check_vmware_vhw_defreq
+    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-minimum-version --trust-cert --log-level info
     }
 
 ```

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-virtual-hardware.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-virtual-hardware.cfg
@@ -74,6 +74,7 @@ define command{
     }
 
 
+
 ######################################
 # Minimum required version check
 ######################################
@@ -105,4 +106,39 @@ define command{
 define command{
     command_name    check_vmware_vhw_minreq_exclude_vms
     command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
+    }
+
+
+
+######################################
+# Default is minimum required version check
+######################################
+
+
+# Look at specific pools only, do not evaluate any VMs that are powered off.
+define command{
+    command_name    check_vmware_vhw_defreq_include_pools
+    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --default-is-min-version --trust-cert --log-level info
+    }
+
+# Look at specific pools only, exclude list of VMs, do not evaluate any VMs
+# that are powered off.
+define command{
+    command_name    check_vmware_vhw_defreq_include_pools_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --ignore-vm '$ARG6$' --default-is-min-version --trust-cert --log-level info
+    }
+
+# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally.
+define command{
+    command_name    check_vmware_vhw_defreq
+    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-min-version --trust-cert --log-level info
+    }
+
+# Look at all pools, exclude list of VMs, do not evaluate any VMs that are
+# powered off.
+define command{
+    command_name    check_vmware_vhw_defreq_exclude_vms
+    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --ignore-vm '$ARG5$' --default-is-min-version --trust-cert --log-level info
     }

--- a/doc.go
+++ b/doc.go
@@ -22,7 +22,7 @@ hosts or vCenter instances) for select (or all) Resource Pools.
 
 • Virtual CPU allocations
 
-• Virtual hardware versions: homogenous, minimum required and outdated-by threshold range checks
+• Virtual hardware versions: homogenous, outdated-by threshold range, minimum required and default is minimum required checks
 
 • Host/Datastore/Virtual Machine pairings (using provided Custom Attribute)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,10 @@ type Config struct {
 	// host or vCenter instance.
 	Domain string
 
+	// ClusterName is the name of the vSphere cluster where monitored objects
+	// reside.
+	ClusterName string
+
 	// LoggingLevel is the supported logging level for this application.
 	LoggingLevel string
 
@@ -277,6 +281,10 @@ type Config struct {
 	// version for a VM is found to be more than this many versions older than
 	// the latest version a CRITICAL state is triggered.
 	VirtualHardwareOutdatedByCritical int
+
+	// VirtualHardwareDefaultVersionIsMinimum indicates whether the host or
+	// cluster default hardware version is the minimum allowed.
+	VirtualHardwareDefaultVersionIsMinimum bool
 
 	// IgnoreMissingCustomAttribute indicates whether a host or datastore
 	// missing the specified Custom Attribute should be ignored.

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -40,6 +40,7 @@ const (
 	datastoreUsageCriticalFlagHelp                  string = "Specifies the percentage of a datastore's storage usage (as a whole number) when a CRITICAL threshold is reached."
 	datastoreUsageWarningFlagHelp                   string = "Specifies the percentage of a datastore's storage usage (as a whole number) when a WARNING threshold is reached."
 	datacenterNameFlagHelp                          string = "Specifies the name of a vSphere Datacenter. If not specified, applicable plugins will attempt to use the default datacenter found in the vSphere environment. Not applicable to standalone ESXi hosts."
+	clusterNameFlagHelp                             string = "Specifies the name of a vSphere Cluster. If not specified, applicable plugins will attempt to use the default cluster found in the vSphere environment. Not applicable to standalone ESXi hosts."
 	snapshotsAgeCriticalFlagHelp                    string = "Specifies the age of a snapshot in days when a CRITICAL threshold is reached."
 	snapshotsAgeWarningFlagHelp                     string = "Specifies the age of a snapshot in days when a WARNING threshold is reached."
 	snapshotsCountCriticalFlagHelp                  string = "Specifies the number of snapshots per VM when a CRITICAL threshold is reached."
@@ -59,6 +60,7 @@ const (
 	virtualHardwareOutdatedByCriticalFlagHelp       string = "If provided, this value is the CRITICAL threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a CRITICAL state is triggered. Required if specifying the WARNING threshold for outdated virtual hardware versions."
 	virtualHardwareOutdatedByWarningFlagHelp        string = "If provided, this value is the WARNING threshold for outdated virtual hardware versions. If the current virtual hardware version for a VM is found to be more than this many versions older than the latest version a WARNING state is triggered. Required if specifying the CRITICAL threshold for outdated virtual hardware versions."
 	virtualHardwareMinimumVersionFlagHelp           string = "If provided, this value is the minimum virtual hardware version accepted for each Virtual Machine. Any Virtual Machine not meeting this minimum value is considered to be in a CRITICAL state. Per KB 1003746, version 3 appears to be the oldest version supported."
+	virtualHardwareDefaultIsMinimumFlagHelp         string = "If specified, the host or cluster default virtual hardware version is the minimum hardware version allowed. Any Virtual Machine not meeting this minimum value is considered to be in a WARNING state."
 )
 
 // Default flag settings if not overridden by user input
@@ -69,6 +71,7 @@ const (
 	defaultUsername                     string = ""
 	defaultPassword                     string = ""
 	defaultUserDomain                   string = ""
+	defaultClusterName                  string = ""
 	defaultPort                         int    = 443
 	defaultBranding                     bool   = false
 	defaultDisplayVersionAndExit        bool   = false
@@ -95,6 +98,10 @@ const (
 	defaultVirtualHardwareMinimumVersion     int = -1
 	defaultVirtualHardwareOutdatedByWarning  int = -1
 	defaultVirtualHardwareOutdatedByCritical int = -1
+
+	// Whether the default host or cluster hardware version is the minimum
+	// version allowed
+	defaultVirtualHardwareDefaultIsMinimum bool = false
 
 	// default memory usage values for Resource Pools and ESXi Host systems
 	defaultMemoryUseCritical int = 95
@@ -143,8 +150,19 @@ const (
 	PluginTypeDatastoresSize                 string = "datastore-size"
 	PluginTypeResourcePoolsMemory            string = "resource-pools-memory"
 	PluginTypeVirtualCPUsAllocation          string = "virtual-cpus-allocation"
+	PluginTypeVirtualHardwareVersion         string = "virtual-hardware-version"
 	PluginTypeHostDatastoreVMsPairings       string = "host-to-ds-to-vms"
 	PluginTypeHostSystemMemory               string = "host-system-memory"
 	PluginTypeHostSystemCPU                  string = "host-system-cpu"
 	PluginTypeVirtualMachinePowerCycleUptime string = "vm-power-uptime"
 )
+
+// Known limits
+// https://trainingrevolution.wordpress.com/2018/07/22/vmware-vsphere-6-7-character-limits-for-objects/
+const (
+	MaxClusterNameChars int = 80
+)
+
+// ThresholdNotUsed indicates that a plugin is not using a specific threshold.
+// This is visible in locations where Long Service Output text is displayed.
+const ThresholdNotUsed string = "Not used by this monitoring mode."

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -182,6 +182,10 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.Var(&c.IgnoredVMs, "ignore-vm", ignoreVMsFlagHelp)
 		flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 
+		flag.StringVar(&c.DatacenterName, "dc-name", defaultDatacenterName, datacenterNameFlagHelp)
+		flag.StringVar(&c.HostSystemName, "host-name", defaultHostSystemName, hostSystemNameFlagHelp)
+		flag.StringVar(&c.ClusterName, "cluster-name", defaultClusterName, clusterNameFlagHelp)
+
 		flag.IntVar(&c.VirtualHardwareOutdatedByWarning, "outdated-by-warning", defaultVirtualHardwareOutdatedByWarning, virtualHardwareOutdatedByWarningFlagHelp)
 		flag.IntVar(&c.VirtualHardwareOutdatedByWarning, "obw", defaultVirtualHardwareOutdatedByWarning, virtualHardwareOutdatedByWarningFlagHelp+" (shorthand)")
 
@@ -190,6 +194,9 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 
 		flag.IntVar(&c.VirtualHardwareMinimumVersion, "minimum-version", defaultVirtualHardwareMinimumVersion, virtualHardwareMinimumVersionFlagHelp)
 		flag.IntVar(&c.VirtualHardwareMinimumVersion, "mv", defaultVirtualHardwareMinimumVersion, virtualHardwareMinimumVersionFlagHelp+" (shorthand)")
+
+		flag.BoolVar(&c.VirtualHardwareDefaultVersionIsMinimum, "default-is-min-version", defaultVirtualHardwareDefaultIsMinimum, virtualHardwareDefaultIsMinimumFlagHelp)
+		flag.BoolVar(&c.VirtualHardwareDefaultVersionIsMinimum, "dimv", defaultVirtualHardwareDefaultIsMinimum, virtualHardwareDefaultIsMinimumFlagHelp+" (shorthand)")
 
 	case pluginType.Host2Datastores2VMs:
 

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -93,7 +93,20 @@ func (c Config) VirtualHardwareApplyMinVersionCheck() bool {
 
 	return c.VirtualHardwareMinimumVersion != defaultVirtualHardwareMinimumVersion &&
 		c.VirtualHardwareOutdatedByCritical == defaultVirtualHardwareOutdatedByCritical &&
-		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning
+		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning &&
+		!c.VirtualHardwareDefaultVersionIsMinimum
+
+}
+
+// VirtualHardwareApplyDefaultIsMinVersionCheck indicates whether all virtual
+// machines are required to have the host or cluster default hardware version
+// or greater. This is only used if the other behaviors were not requested.
+func (c Config) VirtualHardwareApplyDefaultIsMinVersionCheck() bool {
+
+	return c.VirtualHardwareMinimumVersion == defaultVirtualHardwareMinimumVersion &&
+		c.VirtualHardwareOutdatedByCritical == defaultVirtualHardwareOutdatedByCritical &&
+		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning &&
+		c.VirtualHardwareDefaultVersionIsMinimum
 
 }
 
@@ -104,8 +117,9 @@ func (c Config) VirtualHardwareApplyMinVersionCheck() bool {
 func (c Config) VirtualHardwareApplyOutdatedByVersionCheck() bool {
 
 	return c.VirtualHardwareMinimumVersion == defaultVirtualHardwareMinimumVersion &&
-		c.VirtualHardwareOutdatedByCritical != defaultVirtualHardwareOutdatedByCritical &&
-		c.VirtualHardwareOutdatedByWarning != defaultVirtualHardwareOutdatedByWarning
+		(c.VirtualHardwareOutdatedByCritical != defaultVirtualHardwareOutdatedByCritical ||
+			c.VirtualHardwareOutdatedByWarning != defaultVirtualHardwareOutdatedByWarning) &&
+		!c.VirtualHardwareDefaultVersionIsMinimum
 
 }
 
@@ -116,6 +130,7 @@ func (c Config) VirtualHardwareApplyHomogeneousVersionCheck() bool {
 
 	return c.VirtualHardwareMinimumVersion == defaultVirtualHardwareMinimumVersion &&
 		c.VirtualHardwareOutdatedByCritical == defaultVirtualHardwareOutdatedByCritical &&
-		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning
+		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning &&
+		!c.VirtualHardwareDefaultVersionIsMinimum
 
 }

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -116,6 +116,9 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	case pluginType.VirtualCPUsAllocation:
 		appDescription = PluginTypeVirtualCPUsAllocation
 
+	case pluginType.VirtualHardwareVersion:
+		appDescription = PluginTypeVirtualHardwareVersion
+
 	case pluginType.Host2Datastores2VMs:
 		appDescription = PluginTypeHostDatastoreVMsPairings
 

--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -14,9 +14,13 @@ package vsphere
 // twice).
 const ParentResourcePool string = "Resources"
 
-const failedToUseFailedToFallback string = "error: failed to use provided datacenter, failed to fallback to default datacenter"
+const dcFailedToUseFailedToFallback string = "error: failed to use provided datacenter, failed to fallback to default datacenter"
 
 const dcNotProvidedFailedToFallback string = "error: datacenter not provided, failed to fallback to default datacenter"
+
+const crFailedToUseFailedToFallback string = "error: failed to use provided cluster to obtain compute resource, failed to fallback to default compute resource"
+
+const crNotProvidedFailedToFallback string = "error: cluster not provided, failed to fallback to default compute resource"
 
 // virtualHardwareVersionPrefix is used as a prefix for virtual hardware
 // versions used by VirtualMachines. Examples include vmx-15, vmx-14 and so on.

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -66,6 +66,7 @@ func getHostSystemPropsSubset() []string {
 		"datastore",
 		"customValue",
 		"availableField",
+		"parent", // used to obtain ComputeResource
 	}
 }
 func getDatastorePropsSubset() []string {
@@ -235,7 +236,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 	default:
 		dc, findDCErr := finder.DatacenterOrDefault(ctx, datacenter)
 		if findDCErr != nil {
-			return fmt.Errorf("%s: %w", failedToUseFailedToFallback, findDCErr)
+			return fmt.Errorf("%s: %w", dcFailedToUseFailedToFallback, findDCErr)
 		}
 		finder.SetDatacenter(dc)
 	}


### PR DESCRIPTION
Add additional plugin monitoring mode which asserts that virtual
hardware versions for evaluated VMs match or exceed the default
virtual hardware version. The default virtual hardware version
is specified at the host level (if chosen via CLI flag) or
cluster (if chosen via CLI flag, or if host not specified).

Other changes:

- Doc updates, including CLI examples and descriptions of
  supported monitoring modes
- Contrib command definition updates
- Misc bug fixes
  - Missing plugin "type" in log messages due to missing
    constant/check in logging setup
  - Fix invalid preallocaction of vhw slices used by
    `Oldest` and `Newest` `HardwareVersionsIndex` methods

fixes GH-130
refs GH-145
refs GH-33