### PR TITLE
Makefile: Run clean task before single OS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ all: clean windows linux
 
 .PHONY: windows
 ## windows: generates assets for Windows systems
-windows:
+windows: clean
 	@echo "Building release assets for windows ..."
 
 	@for target in $(WHAT); do \
@@ -194,7 +194,7 @@ windows:
 
 .PHONY: linux
 ## linux: generates assets for Linux distros
-linux:
+linux: clean
 	@echo "Building release assets for linux ..."
 
 	@for target in $(WHAT); do \


### PR DESCRIPTION
This is already done for the `all` recipe, but was not used for `linux` and `windows` recipes.

refs GH-160 (loosely related)