### PR TITLE
check_vmware_vm_power_uptime: Fix exit code

### DIFF
--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -279,7 +279,7 @@ func main() {
 			resourcePools,
 		)
 
-		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
+		nagiosExitState.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
 


### PR DESCRIPTION
Replace unintentional `CRITICAL` exit code for `WARNING` state.

fixes GH-166