### PR TITLE
Add VMNames helper func

### DIFF
--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -194,13 +194,9 @@ func main() {
 	log.Debug().Msg("Filter VMs to specified power state")
 	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
 	log.Debug().
-		Str("virtual_machines", strings.Join(vmNames, ", ")).
-		Msg("")
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	// here we diverge from other plugins
 

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -212,11 +212,9 @@ func main() {
 	// log.Debug().Msg("Filter VMs to specified power state")
 	// filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
-	log.Debug().Str("virtual_machines", strings.Join(vmNames, ", ")).Msg("")
+	log.Debug().
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	log.Debug().Msg("Filter VMs to those with snapshots")
 	vmsWithSnapshots := vsphere.FilterVMsWithSnapshots(filteredVMs)

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -212,11 +212,9 @@ func main() {
 	// log.Debug().Msg("Filter VMs to specified power state")
 	// filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
-	log.Debug().Str("virtual_machines", strings.Join(vmNames, ", ")).Msg("")
+	log.Debug().
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	log.Debug().Msg("Filter VMs to those with snapshots")
 	vmsWithSnapshots := vsphere.FilterVMsWithSnapshots(filteredVMs)

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -212,11 +212,9 @@ func main() {
 	// log.Debug().Msg("Filter VMs to specified power state")
 	// filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
-	log.Debug().Str("virtual_machines", strings.Join(vmNames, ", ")).Msg("")
+	log.Debug().
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	log.Debug().Msg("Filter VMs to those with snapshots")
 	vmsWithSnapshots := vsphere.FilterVMsWithSnapshots(filteredVMs)

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -198,13 +198,9 @@ func main() {
 	log.Debug().Msg("Filter VMs to specified power state")
 	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
 	log.Debug().
-		Str("virtual_machines", strings.Join(vmNames, ", ")).
-		Msg("")
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	log.Debug().Msg("Filter VMs to those with VMware Tools issues")
 	vmsWithIssues := vsphere.FilterVMsWithToolsIssues(filteredVMs)

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -207,13 +207,9 @@ func main() {
 	log.Debug().Msg("Filter VMs to specified power state")
 	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
 	log.Debug().
-		Str("virtual_machines", strings.Join(vmNames, ", ")).
-		Msg("")
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	// here we diverge from VMware Tools plugin
 

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -189,13 +189,9 @@ func main() {
 	log.Debug().Msg("Filter VMs to specified power state")
 	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
 	log.Debug().
-		Str("virtual_machines", strings.Join(vmNames, ", ")).
-		Msg("")
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 		// here we diverge from other plugins
 

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -202,13 +202,9 @@ func main() {
 	log.Debug().Msg("Filter VMs to specified power state")
 	filteredVMs = vsphere.FilterVMsByPowerState(filteredVMs, cfg.PoweredOff)
 
-	vmNames := make([]string, 0, len(filteredVMs))
-	for _, vm := range filteredVMs {
-		vmNames = append(vmNames, vm.Name)
-	}
 	log.Debug().
-		Str("virtual_machines", strings.Join(vmNames, ", ")).
-		Msg("")
+		Str("virtual_machines", strings.Join(vsphere.VMNames(filteredVMs), ", ")).
+		Msg("Filtered VMs")
 
 	// here we diverge from other plugins
 

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -481,6 +481,19 @@ func dedupeVMs(vmsList []mo.VirtualMachine) []mo.VirtualMachine {
 	return vmsList[:j]
 }
 
+// VMNames receives a list of VirtualMachine values and returns a new list of
+// VirtualMachine Name values.
+func VMNames(vmsList []mo.VirtualMachine) []string {
+
+	vmNames := make([]string, 0, len(vmsList))
+	for i := range vmsList {
+		vmNames = append(vmNames, vmsList[i].Name)
+	}
+
+	return vmNames
+
+}
+
 // GetVMPowerCycleUptimeStatusSummary accepts a list of VirtualMachines and
 // threshold values and generates a collection of VirtualMachines that exceeds
 // given thresholds along with those given thresholds.


### PR DESCRIPTION
Intended to help reduce duplication and potential shadowing
or misreporting lists of VMs (e.g., those that are filtered
vs the original list).