### PR TITLE
Move feedback breadcrumb to GH Discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ Nagios plugin used to monitor the age of Virtual Machine snapshots.
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please [add a comment to
-GH-79](https://github.com/atc0005/check-vmware/issues/79) providing some
+*only* powered on VMs by default, please [share it
+here](https://github.com/atc0005/check-vmware/discussions/177) providing some
 details for your use-case. In our environment, I have yet to see a need to
 *only* evaluate powered on VMs for old snapshots. For cases where the
 snapshots needed to be ignored, we added the VM to the ignore list. We then
@@ -309,8 +309,8 @@ duration. A maximum of 32 snapshots per Virtual Machine are supported. See
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please [add a comment to
-GH-79](https://github.com/atc0005/check-vmware/issues/79) providing some
+*only* powered on VMs by default, please [share it
+here](https://github.com/atc0005/check-vmware/discussions/177) providing some
 details for your use-case. In our environment, I have yet to see a need to
 *only* evaluate powered on VMs for old snapshots. For cases where the
 snapshots needed to be ignored, we added the VM to the ignore list. We then
@@ -332,8 +332,8 @@ result.
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please [add a comment to
-GH-79](https://github.com/atc0005/check-vmware/issues/79) providing some
+*only* powered on VMs by default, please [share it
+here](https://github.com/atc0005/check-vmware/discussions/177) providing some
 details for your use-case. In our environment, I have yet to see a need to
 *only* evaluate powered on VMs for old snapshots. For cases where the
 snapshots needed to be ignored, we added the VM to the ignore list. We then

--- a/cmd/check_vmware_snapshots_age/doc.go
+++ b/cmd/check_vmware_snapshots_age/doc.go
@@ -8,9 +8,9 @@ Monitor the age of individual snapshots for each Virtual Machine.
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please add a comment to
-https://github.com/atc0005/check-vmware/issues/79 providing some details for
-your use-case.
+*only* powered on VMs by default, please post it to
+https://github.com/atc0005/check-vmware/discussions/177 providing some details
+for your use-case.
 
 The output for this plugin is designed to provide the one-line summary needed
 by Nagios for quick identification of a problem while providing longer, more

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -204,8 +204,8 @@ func main() {
 	// on VMs equally. I'm not sure whether ignoring powered off VMs by
 	// default makes sense for this particular plugin.
 	//
-	// Please share your feedback on this GitHub issue if you feel differently:
-	// https://github.com/atc0005/check-vmware/issues/79
+	// Please share your feedback here if you feel differently:
+	// https://github.com/atc0005/check-vmware/discussions/177
 	//
 	// Please expand on some use cases for ignoring powered off VMs by default.
 	//

--- a/cmd/check_vmware_snapshots_count/doc.go
+++ b/cmd/check_vmware_snapshots_count/doc.go
@@ -11,9 +11,9 @@ https://kb.vmware.com/s/article/1025279 for more information.
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please add a comment to
-https://github.com/atc0005/check-vmware/issues/79 providing some details for
-your use-case.
+*only* powered on VMs by default, please post it to
+https://github.com/atc0005/check-vmware/discussions/177 providing some details
+for your use-case.
 
 The output for this plugin is designed to provide the one-line summary needed
 by Nagios for quick identification of a problem while providing longer, more

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -204,8 +204,8 @@ func main() {
 	// on VMs equally. I'm not sure whether ignoring powered off VMs by
 	// default makes sense for this particular plugin.
 	//
-	// Please share your feedback on this GitHub issue if you feel differently:
-	// https://github.com/atc0005/check-vmware/issues/79
+	// Please share your feedback here if you feel differently:
+	// https://github.com/atc0005/check-vmware/discussions/177
 	//
 	// Please expand on some use cases for ignoring powered off VMs by default.
 	//

--- a/cmd/check_vmware_snapshots_size/doc.go
+++ b/cmd/check_vmware_snapshots_size/doc.go
@@ -13,9 +13,9 @@ result.
 
 The current design of this plugin is to evaluate *all* Virtual Machines,
 whether powered off or powered on. If you have a use case for evaluating
-*only* powered on VMs by default, please add a comment to
-https://github.com/atc0005/check-vmware/issues/79 providing some details for
-your use-case.
+*only* powered on VMs by default, please post it to
+https://github.com/atc0005/check-vmware/discussions/177 providing some details
+for your use-case.
 
 The output for this plugin is designed to provide the one-line summary needed
 by Nagios for quick identification of a problem while providing longer, more

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -204,8 +204,8 @@ func main() {
 	// on VMs equally. I'm not sure whether ignoring powered off VMs by
 	// default makes sense for this particular plugin.
 	//
-	// Please share your feedback on this GitHub issue if you feel differently:
-	// https://github.com/atc0005/check-vmware/issues/79
+	// Please share your feedback here if you feel differently:
+	// https://github.com/atc0005/check-vmware/discussions/177
 	//
 	// Please expand on some use cases for ignoring powered off VMs by default.
 	//

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -35,8 +35,8 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		// on VMs equally. I'm not sure whether ignoring powered off VMs by
 		// default makes sense for this particular plugin.
 		//
-		// Please share your feedback on this GitHub issue if you feel differently:
-		// https://github.com/atc0005/check-vmware/issues/79
+		// Please share your feedback here if you feel differently:
+		// https://github.com/atc0005/check-vmware/discussions/177
 		//
 		// flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 
@@ -56,8 +56,8 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		// on VMs equally. I'm not sure whether ignoring powered off VMs by
 		// default makes sense for this particular plugin.
 		//
-		// Please share your feedback on this GitHub issue if you feel differently:
-		// https://github.com/atc0005/check-vmware/issues/79
+		// Please share your feedback here if you feel differently:
+		// https://github.com/atc0005/check-vmware/discussions/177
 		//
 		// flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 
@@ -77,8 +77,8 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		// on VMs equally. I'm not sure whether ignoring powered off VMs by
 		// default makes sense for this particular plugin.
 		//
-		// Please share your feedback on this GitHub issue if you feel differently:
-		// https://github.com/atc0005/check-vmware/issues/79
+		// Please share your feedback here if you feel differently:
+		// https://github.com/atc0005/check-vmware/discussions/177
 		//
 		// flag.BoolVar(&c.PoweredOff, "powered-off", defaultPoweredOff, poweredOffFlagHelp)
 

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1362,8 +1362,8 @@ func writeSnapshotsReportFooter(
 		// on VMs equally. I'm not sure whether ignoring powered off VMs by
 		// default makes sense for this particular plugin.
 		//
-		// Please share your feedback on this GitHub issue if you feel differently:
-		// https://github.com/atc0005/check-vmware/issues/79
+		// Please share your feedback here if you feel differently:
+		// https://github.com/atc0005/check-vmware/discussions/177
 		//
 		// Please expand on some use cases for ignoring powered off VMs by default.
 		true,


### PR DESCRIPTION
Use GitHub Discussion (GH-176) in place of a GitHub issue which is less suited to the task.

- refs GH-176
- refs GH-79