### PR TITLE
rm incl/excl rps log fields from datastore plugin

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -92,8 +92,6 @@ func main() {
 	}
 
 	log := cfg.Log.With().
-		Str("included_resource_pools", cfg.IncludedResourcePools.String()).
-		Str("excluded_resource_pools", cfg.ExcludedResourcePools.String()).
 		Str("datastore_name", cfg.DatastoreName).
 		Str("datacenter_name", dcName).
 		Int("datastore_critical_usage", cfg.DatastoreUsageCritical).


### PR DESCRIPTION
Those flags are not used by this plugin; any values present (or omitted) from either field in the debug log messages will likely cause confusion for future troubleshooting efforts.