### PR TITLE
Fix multiple mistakes in vc1.example.com host cfg

### DIFF
--- a/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
+++ b/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
@@ -45,7 +45,8 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning threshold in days
     # Argument 5: Critical threshold in days
-    # Argument 6: Comma-separated list of VMs (full names) that are to be ignored
+    # Argument 6: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
+    # Argument 7: Comma-separated list of VMs (full names) that are to be ignored
     }
 
 define service{
@@ -59,7 +60,8 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning threshold in snapshots count (e.g., 4)
     # Argument 5: Critical threshold in snapshots count (e.g., 25 of 32 max)
-    # Argument 6: Comma-separated list of VMs (full names) that are to be ignored
+    # Argument 6: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
+    # Argument 7: Comma-separated list of VMs (full names) that are to be ignored
     }
 
 define service{
@@ -73,7 +75,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning threshold in GB
     # Argument 5: Critical threshold in GB
-    # Argument 6: Comma-separated list of VMs (full names) that are to be ignored
+    # Argument 6: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
     }
 
 define service{
@@ -140,6 +142,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning memory threshold in percentage, given as whole number
     # Argument 5: Critical memory threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -153,6 +156,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning memory threshold in percentage, given as whole number
     # Argument 5: Critical memory threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -166,6 +170,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning memory threshold in percentage, given as whole number
     # Argument 5: Critical memory threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -179,6 +184,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning CPU threshold in percentage, given as whole number
     # Argument 5: Critical CPU threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -192,6 +198,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning CPU threshold in percentage, given as whole number
     # Argument 5: Critical CPU threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -205,6 +212,7 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning CPU threshold in percentage, given as whole number
     # Argument 5: Critical CPU threshold in percentage, given as whole number
+    # Argument 6: ESXi hostname as seen within vSphere client
     }
 
 define service{
@@ -319,7 +327,7 @@ define service{
     # Argument 6: Max vCPUs allowed per lease agreement
     #             20 vCPUs per VRU, 8x VRUs so 160 vCPUs
     #             allowed for ALL of our (powered on) VMs.
-    # Argument 7: List of Resource Pools to restrict checks to
+    # Argument 7: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
     }
 
 define service{
@@ -333,5 +341,5 @@ define service{
     # Argument 3: Service Account password (see resource.cfg)
     # Argument 4: Warning threshold in days
     # Argument 5: Critical threshold in days
-    # Argument 6: Comma-separated list of VMs (full names) that are to be ignored
+    # Argument 6: Comma-separated list of Resource Pools (full names) that are to be evaluated (all others ignored)
     }


### PR DESCRIPTION
Spotted these while working on a new feature request. Some are copy/paste/modify errors, others are likely from earlier attempts to sanitize a production configuration for sharing via this repo.