### PR TITLE
disk consol plugin: Fix power off/on eval stmts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1796,9 +1796,8 @@ Of note:
 ```shell
 # /etc/nagios-plugins/config/vmware-disk-consolidation.cfg
 
-# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
-# This variation of the command is most useful for environments where all VMs
-# are monitored equally.
+# Look at all pools, all VMs. This variation of the command is most useful for
+# environments where all VMs are monitored equally.
 define command{
     command_name    check_vmware_disk_consolidation
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
@@ -18,9 +18,8 @@ define command{
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
-# Look at all pools, all VMs, do not evaluate any VMs that are powered off.
-# This variation of the command is most useful for environments where all VMs
-# are monitored equally.
+# Look at all pools, all VMs. This variation of the command is most useful for
+# environments where all VMs are monitored equally.
 define command{
     command_name    check_vmware_disk_consolidation
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info


### PR DESCRIPTION
Fix incorrect statements that powered off VMs are not evaluated whether disk consolidation is needed.

- refs GH-189
- refs GH-183
- refs GH-188