### PR TITLE
check_vmware_question | Fix invalid threshold text

### DIFF
--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -72,7 +72,7 @@ func main() {
 	// Record thresholds for use as Nagios "Long Service Output" content. This
 	// content is shown in the detailed web UI and in notifications generated
 	// by Nagios.
-	nagiosExitState.CriticalThreshold = "Disk consolidation needed for one or more Virtual Machines."
+	nagiosExitState.CriticalThreshold = "One or more Virtual Machines blocked by an interactive question"
 
 	nagiosExitState.WarningThreshold = config.ThresholdNotUsed
 


### PR DESCRIPTION
I evidently forgot to update this value when using another plugin as a template.

fixes GH-197