### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,9 +25,16 @@ linters:
     - goimports
     - golint
     - gosec
-    - maligned
     - misspell
     - prealloc
-    - scopelint
+    - exportloopref
     - stylecheck
     - unconvert
+
+  disable:
+    - maligned
+
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment


### PR DESCRIPTION
- replace deprecated `maligned` linter with `govet: fieldalignment`
- replace deprecated `scopelint` linter with `exportloopref`

fixes GH-202
