### PR TITLE
Fix govet:fieldalignment linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,27 @@ type Config struct {
 	// vSphere inventory.
 	HostSystemName string
 
+	// IncludedResourcePools lists resource pools that are explicitly
+	// monitored. Specifying list values automatically excludes VirtualMachine
+	// objects outside a Resource Pool.
+	IncludedResourcePools multiValueStringFlag
+
+	// ExcludedResourcePools lists resource pools that are explicitly ignored
+	// or excluded from being monitored.
+	ExcludedResourcePools multiValueStringFlag
+
+	// IgnoredVM is a list of VMs that are explicitly ignored or excluded
+	// from being monitored.
+	IgnoredVMs multiValueStringFlag
+
+	// IgnoredDatastores is a list of datastore names for Datastores that are
+	// allowed to be associated with a VirtualMachine that are not associated
+	// with its current host.
+	IgnoredDatastores multiValueStringFlag
+
+	// Log is an embedded zerolog Logger initialized via config.New().
+	Log zerolog.Logger
+
 	// HostSystemMemoryUseWarning specifies the percentage of memory use (as a
 	// whole number) for the specified ESXi host when a WARNING threshold is
 	// reached.
@@ -309,27 +330,6 @@ type Config struct {
 	// ShowVersion is a flag indicating whether the user opted to display only
 	// the version string and then immediately exit the application.
 	ShowVersion bool
-
-	// IncludedResourcePools lists resource pools that are explicitly
-	// monitored. Specifying list values automatically excludes VirtualMachine
-	// objects outside a Resource Pool.
-	IncludedResourcePools multiValueStringFlag
-
-	// ExcludedResourcePools lists resource pools that are explicitly ignored
-	// or excluded from being monitored.
-	ExcludedResourcePools multiValueStringFlag
-
-	// IgnoredVM is a list of VMs that are explicitly ignored or excluded
-	// from being monitored.
-	IgnoredVMs multiValueStringFlag
-
-	// IgnoredDatastores is a list of datastore names for Datastores that are
-	// allowed to be associated with a VirtualMachine that are not associated
-	// with its current host.
-	IgnoredDatastores multiValueStringFlag
-
-	// Log is an embedded zerolog Logger initialized via config.New().
-	Log zerolog.Logger
 }
 
 // Usage is a custom override for the default Help text provided by the flag

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -43,8 +43,8 @@ var ErrHostDatastorePairingFailed = errors.New("failed to compile host/datastore
 // occur if the datastore for a VM is in a user-specified ignored datastores
 // list.
 type ErrHostDatastoreIdxIDToNameLookupFailed struct {
-	DatastoreID string
 	Err         error
+	DatastoreID string
 }
 
 func (dsIDFail ErrHostDatastoreIdxIDToNameLookupFailed) Error() string {

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -106,6 +106,9 @@ type SnapshotThresholds struct {
 // snapshot details for a specific VirtualMachine snapshot.
 type SnapshotSummary struct {
 
+	// createTime is when the snapshot was created.
+	createTime time.Time
+
 	// Name of the snapshot in human readable format.
 	Name string
 
@@ -115,8 +118,7 @@ type SnapshotSummary struct {
 	// Description of the snapshot in human readable format.
 	Description string
 
-	// createTime is when the snapshot was created.
-	createTime time.Time
+	VMName string
 
 	// Size is the size of the snapshot.
 	Size int64
@@ -140,8 +142,6 @@ type SnapshotSummary struct {
 	// sizeCriticalState indicates whether this snapshot is considered in a
 	// CRITICAL state based on crossing snapshot size threshold.
 	sizeCriticalState bool
-
-	VMName string
 }
 
 // SnapshotSummarySet ties a collection of snapshot summary values to a


### PR DESCRIPTION
Change field order of affected structs in order to reduce allocation requirements and pass `fieldalignment` linting check.

fixes GH-204