### PR TITLE
Add missing doc comments for getObjects func

### DIFF
--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -82,6 +82,9 @@ func getDatastorePropsSubset() []string {
 	}
 }
 
+// getObjects retrieves one or more objects, filtered by the provided
+// container type ManagedObjectReference. An error is returned if the provided
+// ManagedObjectReference is not for a supported container type.
 func getObjects(ctx context.Context, c *vim25.Client, dst interface{}, objRef types.ManagedObjectReference, propsSubset bool) error {
 
 	funcTimeStart := time.Now()


### PR DESCRIPTION
There are likely other functions in need of documentation (or better documentation), but this one took a bit of
"cob web digging" to remember its purpose and why I didn't use another approach at the time.