### PR TITLE
Remove unintentional flag from example cmd defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1976,7 +1976,7 @@ Of note:
 # any triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-type '$ARG4' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 ```
 

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
@@ -17,7 +17,7 @@
 # any triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-type '$ARG4' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms for all managed object types (e.g., Datastore and


### PR DESCRIPTION
Remove unintentional `--include-type` flag from the "monitor all" command definition.

fixes GH-227