### PR TITLE
tests: Fix order of args for cmp.Diff()

### DIFF
--- a/cmd/check_vmware_alarms/main_test.go
+++ b/cmd/check_vmware_alarms/main_test.go
@@ -608,7 +608,7 @@ func TestFilters(t *testing.T) {
 						len(remainingTriggeredAlarmKeys),
 					)
 
-					if d := cmp.Diff(tt.wantedNonExcludedAlarmKeysAfterFiltering, remainingTriggeredAlarmKeys); d != "" {
+					if d := cmp.Diff(remainingTriggeredAlarmKeys, tt.wantedNonExcludedAlarmKeysAfterFiltering); d != "" {
 						t.Logf("(-got, +want)\n:%s", d)
 					}
 


### PR DESCRIPTION
This change corrects the argument order which in turn corrects the output shown when comparison of alarm results indicates a failed match between what we want and what we got.