### PR TITLE
Add missing plugin type field value to logger

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -111,6 +111,9 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	case pluginType.InteractiveQuestion:
 		appDescription = PluginTypeInteractiveQuestion
 
+	case pluginType.Alarms:
+		appDescription = PluginTypeAlarms
+
 	case pluginType.Tools:
 		appDescription = PluginTypeTools
 


### PR DESCRIPTION
This was missed when initially creating the new plugin.

fixes GH-259