### PR TITLE
Track & report triggered alarm exclusion reason

### DIFF
--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -61,3 +61,15 @@ const (
 	alarmName        string = "AlarmName"
 	entityName       string = "EntityName"
 )
+
+// used to track why a TriggeredAlarm was excluded, displayed in
+// LongServiceOutput/report.
+const (
+	alarmExcludeReasonAlarmAcknowledged  = "alarm is acknowledged"
+	alarmExcludeReasonAlarmName          = "alarm name"
+	alarmExcludeReasonAlarmDescription   = "alarm desc"
+	alarmExcludeReasonAlarmStatus        = "alarm status"
+	alarmExcludeReasonEntityType         = "object type"
+	alarmExcludeReasonEntityName         = "object name"
+	alarmExcludeReasonEntityResourcePool = "resource pool"
+)


### PR DESCRIPTION
Track reason for exclusion, note this in the report given at end of plugin execution. This should help explain at a glance why a triggered alarm was not reported.

fixes GH-263