### PR TITLE
Reorder cmd def params, update host svc checks

### DIFF
--- a/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
@@ -50,7 +50,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_type
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-type '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$'  --trust-cert --log-level info
     }
 
 # Look at triggered alarms for specified managed object types (e.g., Datastore
@@ -58,7 +58,7 @@ define command{
 # alarms which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_type_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-type '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects which do not match
@@ -67,7 +67,7 @@ define command{
 # alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_type
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-type '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects which do not match
@@ -76,7 +76,7 @@ define command{
 # which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_type_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-type '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -90,7 +90,7 @@ define command{
 # acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-name '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name matches the specified list of alarm name
@@ -99,7 +99,7 @@ define command{
 # not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-name '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name does not match the specified list of
@@ -108,7 +108,7 @@ define command{
 # acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-name '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name does not match the specified list of
@@ -117,7 +117,7 @@ define command{
 # acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-name '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -131,7 +131,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_desc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-desc '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description matches the specified list of
@@ -140,7 +140,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_desc_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-desc '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description does not match the specified list
@@ -149,7 +149,7 @@ define command{
 # have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_desc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-desc '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description does not match the specified list
@@ -158,7 +158,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_desc_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-desc '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -172,7 +172,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_status
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-status '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status matches the specified list of
@@ -181,7 +181,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_status_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-status '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status does not match the specified list of
@@ -190,7 +190,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_status
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-status '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status does not match the specified list of
@@ -199,7 +199,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_status_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-status '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -213,7 +213,7 @@ define command{
 # have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-name '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name matches
@@ -222,7 +222,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-name '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name does not
@@ -231,7 +231,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-name '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name does not
@@ -240,7 +240,7 @@ define command{
 # alarms which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-name '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -254,7 +254,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-rp '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose resource pool
@@ -263,7 +263,7 @@ define command{
 # have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_pools_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-entity-rp '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose resource pool name does not match the
@@ -272,7 +272,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-rp '$ARG4$' --dc-name '$ARG5$' --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose resource pool name does not match the
@@ -281,5 +281,5 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_pools_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --exclude-entity-rp '$ARG4$' --dc-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
+++ b/contrib/nagios/etc/nagios3/conf/hosts/servers/vc1.example.com.cfg
@@ -381,11 +381,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Exclude datastore usage
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_exclude_names!example!vc1-read-only-service-account!$USER13$!"datastore usage on disk"
+    check_command           check_vmware_alarms_specific_dc_exclude_names!example!vc1-read-only-service-account!$USER13$!"example"!"datastore usage on disk"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm name substrings
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm name substrings
     }
 
 define service{
@@ -393,11 +394,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Datastore usage only
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_names!example!vc1-read-only-service-account!$USER13$!"datastore usage on disk"
+    check_command           check_vmware_alarms_specific_dc_include_names!example!vc1-read-only-service-account!$USER13$!"example"!"datastore usage on disk"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm name substrings
+    # Argument 4: Datacenter name
+    # Argument 5: Comma-separated list of Triggered Alarm name substrings
     }
 
 define service{
@@ -405,11 +407,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Server Support RP only
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_entity_pools!example!vc1-read-only-service-account!$USER13$!"Server Support"
+    check_command           check_vmware_alarms_specific_dc_include_entity_pools!example!vc1-read-only-service-account!$USER13$!"example"!"Server Support"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm entity resource pool names
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm entity resource pool names
     }
 
 define service{
@@ -417,11 +420,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Exclude Development RP
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_exclude_entity_pools!example!vc1-read-only-service-account!$USER13$!"Development"
+    check_command           check_vmware_alarms_specific_dc_exclude_entity_pools!example!vc1-read-only-service-account!$USER13$!"example"!"Development"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm entity resource pool names
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm entity resource pool names
     }
 
 define service{
@@ -429,11 +433,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - ESXi hosts
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_entity_name!example!vc1-read-only-service-account!$USER13$!"esx1", "esx2", "esx3"
+    check_command           check_vmware_alarms_specific_dc_include_entity_name!example!vc1-read-only-service-account!$USER13$!"example"!"esx1", "esx2", "esx3"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm entity name substrings
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm entity name substrings
     }
 
 define service{
@@ -441,11 +446,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Critical status
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_status!example!vc1-read-only-service-account!$USER13$!"critical"
+    check_command           check_vmware_alarms_specific_dc_include_status!example!vc1-read-only-service-account!$USER13$!"example"!"critical"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm status keywords
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm status keywords
     }
 
 define service{
@@ -453,11 +459,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Exclude Warning status
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_exclude_status!example!vc1-read-only-service-account!$USER13$!"warning"
+    check_command           check_vmware_alarms_specific_dc_exclude_status!example!vc1-read-only-service-account!$USER13$!"example"!"warning"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm status keywords
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm status keywords
     }
 
 define service{
@@ -465,11 +472,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Disk consolidation needed by alarm description
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_desc!example!vc1-read-only-service-account!$USER13$!"Consolidation Needed status is set"
+    check_command           check_vmware_alarms_specific_dc_include_desc!example!vc1-read-only-service-account!$USER13$!"example"!"Consolidation Needed status is set"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm description substrings
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm description substrings
     }
 
 define service{
@@ -477,11 +485,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Exclude default CPU usage by alarm description
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_exclude_desc!example!vc1-read-only-service-account!$USER13$!"Default alarm to monitor virtual machine CPU usage"
+    check_command           check_vmware_alarms_specific_dc_exclude_desc!example!vc1-read-only-service-account!$USER13$!"example"!"Default alarm to monitor virtual machine CPU usage"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm description substrings
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm description substrings
     }
 
 define service{
@@ -489,11 +498,12 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Virtual Machines
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_include_entity_type!example!vc1-read-only-service-account!$USER13$!"VirtualMachine"
+    check_command           check_vmware_alarms_specific_dc_include_entity_type!example!vc1-read-only-service-account!$USER13$!"example"!"VirtualMachine"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm entity type keywords
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm entity type keywords
     }
 
 define service{
@@ -501,9 +511,10 @@ define service{
     host_name               vc1.exmaple.com
     service_description     VMware Triggered Alarms - Exclude Datastores
     servicegroups           vmware-checks, vmware-alarm-checks
-    check_command           check_vmware_alarms_specific_dc_exclude_entity_type!example!vc1-read-only-service-account!$USER13$!"Datastore"
+    check_command           check_vmware_alarms_specific_dc_exclude_entity_type!example!vc1-read-only-service-account!$USER13$!"example"!"Datastore"
     # Argument 1: User Domain
     # Argument 2: Service Account username
     # Argument 3: Service Account password (see resource.cfg)
-    # Argument 4: Comma-separated list of Triggered Alarm entity type keywords
+    # Argument 4: Comma-separated list of Datacenter names
+    # Argument 5: Comma-separated list of Triggered Alarm entity type keywords
     }


### PR DESCRIPTION
While adding the missing DCs args to the host service checks, I opted to reorder the command definition flags
in order to place the include/exclude lists at the end. This allows the service checks to be defined with the longer lists of details (the include/exclude lists) also at the end.

The assumption is that this order will more closely match existing service checks that have lists of values at the end.

fixes GH-268
