### PR TITLE
Update atc0005/send2teams cmd def to use new flag

### DIFF
--- a/contrib/nagios/etc/nagios-plugins/config/send2teams.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/send2teams.cfg
@@ -9,14 +9,11 @@
 # 'notify-host-by-teams' command definition
 define command{
     command_name    notify-host-by-teams
-    command_line    /usr/local/bin/send2teams -convert-eol -retries 4 -retries-delay 5 -team "IT Dept" -channel "Alerts" -title "$NOTIFICATIONTYPE$ Host Alert: $HOSTNAME$ is $HOSTSTATE$" -color "#5c5303" -message "<br>Notification Type: $NOTIFICATIONTYPE$<br>Host: $HOSTNAME$<br>State: $HOSTSTATE$<br>Address: $HOSTADDRESS$<br>Info: $HOSTOUTPUT$<br><br>Date/Time: $LONGDATETIME$<br>" -url "$USER101$"
+    command_line    /usr/local/bin/send2teams -convert-eol -retries 4 -retries-delay 5 -team "Library - Systems" -channel "Alerts" -title "$NOTIFICATIONTYPE$ Host Alert: $HOSTNAME$ is $HOSTSTATE$" -color "#5c5303" -message "<br>Notification Type: $NOTIFICATIONTYPE$<br>Host: $HOSTNAME$<br>State: $HOSTSTATE$<br>Address: $HOSTADDRESS$<br>Info: $HOSTOUTPUT$<br><br>Date/Time: $LONGDATETIME$<br>" -url "$USER101$" -sender "Nagios" -target-url 'https://nagios.example.com/cgi-bin/nagios3/status.cgi?host=$HOSTNAME$, View services for $HOSTNAME$' -target-url 'https://redmine.example.com/redmine/search?utf8=%E2%9C%93&scope=&q=$NOTIFICATIONTYPE$ Host Alert: $HOSTNAME$ is $HOSTSTATE$, Search Redmine for related tickets'
     }
 
 # 'notify-service-by-teams' command definition
 define command{
     command_name    notify-service-by-teams
-    command_line    /usr/local/bin/send2teams -convert-eol -retries 4 -retries-delay 5 -team "IT Dept" -channel "Alerts" -title "$NOTIFICATIONTYPE$ Service Alert: \"$SERVICEDESC$\" for $HOSTNAME$ is $SERVICESTATE$" -color "#5c5303" -message "<br>Notification Type: $NOTIFICATIONTYPE$<br><br>Service: $SERVICEDESC$<br>Host: $HOSTALIAS$<br>Address: $HOSTADDRESS$<br>State: $SERVICESTATE$<br><br>Date/Time: $LONGDATETIME$<br><br>Additional Info:<br><br>\`$SERVICEOUTPUT$\`<br><br>$LONGSERVICEOUTPUT$" -url "$USER101$"
+    command_line    /usr/local/bin/send2teams -convert-eol -retries 4 -retries-delay 5 -team "Library - Systems" -channel "Alerts" -title "$NOTIFICATIONTYPE$ Service Alert: \"$SERVICEDESC$\" for $HOSTNAME$ is $SERVICESTATE$" -color "#5c5303" -message "<br>Notification Type: $NOTIFICATIONTYPE$<br><br>Service: $SERVICEDESC$<br>Host: $HOSTALIAS$<br>Address: $HOSTADDRESS$<br>State: $SERVICESTATE$<br><br>Date/Time: $LONGDATETIME$<br><br>Additional Info:<br><br>\`$SERVICEOUTPUT$\`<br><br>$LONGSERVICEOUTPUT$" -url "$USER101$" -sender "Nagios" -target-url 'https://nagios.example.com/cgi-bin/nagios3/extinfo.cgi?type=2&host=$HOSTNAME$&service=$SERVICEDESC$, View service on Nagios console' -target-url 'https://redmine.example.com/redmine/search?utf8=%E2%9C%93&scope=&q=$NOTIFICATIONTYPE$ Service Alert: %22$SERVICEDESC$%22 for $HOSTNAME$ is $SERVICESTATE$, Search Redmine for related tickets'
     }
-
-
-# ./send2teams.exe -retries 4 -retries-delay 5 -channel "Testing" -message "Testing from command-line!" -title "Another test" -color "#832561" -url "https://outlook.office.com/webhook/www@xxx/IncomingWebhook/yyy/zzz"


### PR DESCRIPTION
- Add new `--target-url` flag
  - include link back to Nagios console web UI for affected
    host or service
  - include link to Redmine ticketing system for earlier
    tickets of the same name
- Remove earlier CLI usage example provided at the bottom of
  the file
  - by this point it is dated, missing this and the prior
    flag addition and doesn't really add as much value
    as originally intended

fixes GH-271