### PR TITLE
Set & report custom user agent for all plugins

### DIFF
--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -90,6 +90,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -102,6 +102,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -91,6 +91,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -101,6 +101,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -102,6 +102,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -98,6 +98,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -91,6 +91,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -118,6 +118,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -99,6 +99,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -99,6 +99,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -99,6 +99,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -94,6 +94,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -103,6 +103,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -85,6 +85,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -98,6 +98,7 @@ func main() {
 	c, loginErr := vsphere.Login(
 		ctx, cfg.Server, cfg.Port, cfg.TrustCert,
 		cfg.Username, cfg.Domain, cfg.Password,
+		cfg.UserAgent(),
 	)
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -156,7 +156,9 @@ const (
 	defaultCustomAttributePrefixSeparator string = ""
 )
 
-// Plugin types provided by this project.
+// Plugin types provided by this project. These values are used as labels in
+// logging and report output. See also the PluginType struct type used to
+// indicate what plugin is executing.
 const (
 	PluginTypeTools                          string = "vmware-tools"
 	PluginTypeSnapshotsAge                   string = "snapshots-age"

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -7,7 +7,10 @@
 
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // Timeout converts the user-specified connection timeout value in
 // seconds to an appropriate time duration value for use with setting
@@ -132,5 +135,19 @@ func (c Config) VirtualHardwareApplyHomogeneousVersionCheck() bool {
 		c.VirtualHardwareOutdatedByCritical == defaultVirtualHardwareOutdatedByCritical &&
 		c.VirtualHardwareOutdatedByWarning == defaultVirtualHardwareOutdatedByWarning &&
 		!c.VirtualHardwareDefaultVersionIsMinimum
+
+}
+
+// UserAgent returns a string usable as-is as a custom user agent for plugins
+// provided by this project.
+func (c Config) UserAgent() string {
+
+	// Default User Agent: (Go-http-client/1.1)
+	// https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-p2-semantics-22#section-5.5.3
+	return fmt.Sprintf(
+		"%s/%s",
+		c.App.Name,
+		c.App.Version,
+	)
 
 }

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -69,56 +69,6 @@ func setLoggingLevel(logLevel string) error {
 // application
 func (c *Config) setupLogging(pluginType PluginType) error {
 
-	var appDescription string
-
-	switch {
-	case pluginType.SnapshotsAge:
-		appDescription = PluginTypeSnapshotsAge
-
-	case pluginType.SnapshotsCount:
-		appDescription = PluginTypeSnapshotsCount
-
-	case pluginType.SnapshotsSize:
-		appDescription = PluginTypeSnapshotsSize
-
-	case pluginType.DatastoresSize:
-		appDescription = PluginTypeDatastoresSize
-
-	case pluginType.ResourcePoolsMemory:
-		appDescription = PluginTypeResourcePoolsMemory
-
-	case pluginType.VirtualCPUsAllocation:
-		appDescription = PluginTypeVirtualCPUsAllocation
-
-	case pluginType.VirtualHardwareVersion:
-		appDescription = PluginTypeVirtualHardwareVersion
-
-	case pluginType.Host2Datastores2VMs:
-		appDescription = PluginTypeHostDatastoreVMsPairings
-
-	case pluginType.HostSystemMemory:
-		appDescription = PluginTypeHostSystemMemory
-
-	case pluginType.HostSystemCPU:
-		appDescription = PluginTypeHostSystemCPU
-
-	case pluginType.VirtualMachinePowerCycleUptime:
-		appDescription = PluginTypeVirtualMachinePowerCycleUptime
-
-	case pluginType.DiskConsolidation:
-		appDescription = PluginTypeDiskConsolidation
-
-	case pluginType.InteractiveQuestion:
-		appDescription = PluginTypeInteractiveQuestion
-
-	case pluginType.Alarms:
-		appDescription = PluginTypeAlarms
-
-	case pluginType.Tools:
-		appDescription = PluginTypeTools
-
-	}
-
 	// We set some common fields here so that we don't have to repeat them
 	// explicitly later and then set additional fields while processing each
 	// email account. This approach is intended to help standardize the log
@@ -128,7 +78,7 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 	c.Log = zerolog.New(os.Stderr).With().Timestamp().Caller().
 		Str("version", Version()).
 		Str("logging_level", c.LoggingLevel).
-		Str("plugin_type", appDescription).
+		Str("plugin_type", pluginTypeLabel(pluginType)).
 		Str("connection_timeout", c.Timeout().String()).
 		Str("username", c.Username).
 		Str("user_domain", c.Domain).

--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -1721,6 +1721,13 @@ func AlarmsReport(
 
 	fmt.Fprintf(
 		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
 		"* Triggered Alarms (evaluated: %d, ignored: %d, total: %d)%s",
 		numTriggeredAlarmsToReport,
 		triggeredAlarms.NumExcluded(),

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -341,5 +341,12 @@ func DatastoreUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
+	fmt.Fprintf(
+		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
 	return report.String()
 }

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -593,6 +593,13 @@ func VirtualHardwareReport(
 
 	fmt.Fprintf(
 		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
 		"* Default Virtual Hardware Version: %d (%s) %s",
 		defaultHardwareVersion.VersionNumber(),
 		defaultHardwareVersion.String(),

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -623,6 +623,13 @@ func H2D2VMsReport(
 
 	fmt.Fprintf(
 		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
 		"* VMs (evaluated: %d, total: %d)%s",
 		len(evaluatedVMs),
 		len(allVMs),

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -572,6 +572,13 @@ func HostSystemMemoryUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
+	fmt.Fprintf(
+		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
 	return report.String()
 }
 
@@ -779,6 +786,13 @@ func HostSystemCPUUsageReport(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -503,6 +503,13 @@ func ResourcePoolsMemoryReport(
 
 	fmt.Fprintf(
 		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
 		"* Specified Resource Pools to explicitly include (%d): [%v]%s",
 		len(includeRPs),
 		strings.Join(includeRPs, ", "),

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1349,6 +1349,13 @@ func writeSnapshotsReportFooter(
 
 	fmt.Fprintf(
 		w,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		w,
 		"* VMs (evaluated: %d, total: %d)%s",
 		len(evaluatedVMs),
 		len(allVMs),

--- a/internal/vsphere/tools.go
+++ b/internal/vsphere/tools.go
@@ -221,6 +221,13 @@ func VMToolsReport(
 
 	fmt.Fprintf(
 		&vmsReport,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&vmsReport,
 		"* VMs (evaluated: %d, total: %d)%s",
 		len(evaluatedVMs),
 		len(allVMs),

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -139,6 +139,13 @@ func VirtualCPUsReport(
 
 	fmt.Fprintf(
 		&vmsReport,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&vmsReport,
 		"* VMs (evaluated: %d, total: %d)%s",
 		len(evaluatedVMs),
 		len(allVMs),

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -752,6 +752,13 @@ func VMPowerCycleUptimeReport(
 
 	fmt.Fprintf(
 		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
 		"* VMs (evaluated: %d, total: %d)%s",
 		len(evaluatedVMs),
 		len(allVMs),
@@ -910,6 +917,13 @@ func VMDiskConsolidationReport(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
@@ -1096,6 +1110,13 @@ func VMInteractiveQuestionReport(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
+		nagios.CheckOutputEOL,
+	)
+
+	fmt.Fprintf(
+		&report,
+		"* Plugin User Agent: %s%s",
+		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 


### PR DESCRIPTION
Override default user agent (`Go-http-client/1.1`) with this
project name and current version (e.g., `check-vmware/x.y.z`).

Explicitly report custom user agent in Long Service Ouput
for all plugins.

The intent is to help vCenter / vSphere admins identify
whether a plugin from this project is misbehaving and causing
issues and provide a quick reminder to sysadmins what version
of the plugins is being used along with what user agent is
being reported to the vSphere instance.

Very minor refactoring applied to provide a helper function
for retrieving applicable plugin "label" or description details.

fixes GH-209