### PR TITLE
Makefile: Remove empty plugin-specific subdirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ goclean:
 	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-linux-*)
 	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-windows-*)
 	@rm -vf $(wildcard ${OUTPUTDIR}/*-links.txt)
+	@find ${OUTPUTDIR} -mindepth 1 -type d -empty -delete
 
 .PHONY: clean
 ## clean: alias for goclean


### PR DESCRIPTION
Remove empty subdirectories when removing build artifacts.

fixes GH-329
refs https://unix.stackexchange.com/a/107556/239904