### PR TITLE
Update Makefile recipes to be more granular

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,50 +181,93 @@ pristine: goclean gitclean
 all: clean windows linux
 	@echo "Completed all cross-platform builds ..."
 
-.PHONY: windows
-## windows: generates assets for Windows systems
-windows: clean
-	@echo "Building release assets for windows ..."
+.PHONY: windows-x86
+## windows-x86: generates assets for Windows x86 systems
+windows-x86:
+	@echo "Building release assets for windows x86 ..."
 
 	@for target in $(WHAT); do \
 		mkdir -p $(ROOT_PATH)/$$target && \
 		echo "  Building $$target 386 binaries" && \
 		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-windows-386.exe ${PWD}/cmd/$$target && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-windows-386.exe" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
+		echo "  Generating $$target checksum files" && \
+		cd $(ROOT_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-windows-386.exe > $$target-$(VERSION)-windows-386.exe.sha256 && \
+		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-windows-386.exe.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed build tasks for windows x86"
+
+.PHONY: windows-x64
+## windows-x64: generates assets for Windows x64 systems
+windows-x64:
+	@echo "Building release assets for windows x64 ..."
+
+	@for target in $(WHAT); do \
+		mkdir -p $(ROOT_PATH)/$$target && \
 		echo "  Building $$target amd64 binaries" && \
 		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-windows-amd64.exe ${PWD}/cmd/$$target && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-windows-amd64.exe" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		echo "  Generating $$target checksum files" && \
 		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-windows-386.exe > $$target-$(VERSION)-windows-386.exe.sha256 && \
-		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-windows-386.exe.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		$(CHECKSUMCMD) $$target-$(VERSION)-windows-amd64.exe > $$target-$(VERSION)-windows-amd64.exe.sha256 && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-windows-amd64.exe.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		cd $$OLDPWD; \
 	done
 
-	@echo "Completed build tasks for windows"
+	@echo "Completed build tasks for windows x64"
 
-.PHONY: linux
-## linux: generates assets for Linux distros
-linux: clean
-	@echo "Building release assets for linux ..."
+.PHONY: windows
+## windows: generates assets for Windows x86 and x64 systems
+windows: windows-x86 windows-x64
+	@echo "Completed all build tasks for windows"
+
+.PHONY: linux-x86
+## linux-x86: generates assets for Linux x86 distros
+linux-x86:
+	@echo "Building release assets for linux x86 ..."
 
 	@for target in $(WHAT); do \
 		mkdir -p $(ROOT_PATH)/$$target && \
 		echo "  Building $$target 386 binaries" && \
 		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-linux-386 ${PWD}/cmd/$$target && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-linux-386" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
+		echo "  Generating $$target checksum files" && \
+		cd $(ROOT_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-$(VERSION)-linux-386 > $$target-$(VERSION)-linux-386.sha256 && \
+		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-linux-386.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed build tasks for linux x86"
+
+.PHONY: linux-x64
+## linux-x64: generates assets for Linux x64 distros
+linux-x64:
+	@echo "Building release assets for linux x64 ..."
+
+	@for target in $(WHAT); do \
+		mkdir -p $(ROOT_PATH)/$$target && \
 		echo "  Building $$target amd64 binaries" && \
 		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-linux-amd64 ${PWD}/cmd/$$target && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-linux-amd64" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		echo "  Generating $$target checksum files" && \
 		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-linux-386 > $$target-$(VERSION)-linux-386.sha256 && \
-		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-linux-386.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		$(CHECKSUMCMD) $$target-$(VERSION)-linux-amd64 > $$target-$(VERSION)-linux-amd64.sha256 && \
 		echo "$(BASE_URL)/$(VERSION)/$$target-$(VERSION)-linux-amd64.sha256" >> $(ROOT_PATH)/$(VERSION)-links.txt && \
 		cd $$OLDPWD; \
 	done
 
-	@echo "Completed build tasks for linux"
+	@echo "Completed build tasks for linux x64"
+
+.PHONY: linux
+## linux: generates assets for Linux x86 and x64 distros
+linux: linux-x86 linux-x64
+	@echo "Completed all build tasks for linux"
+
+.PHONY: release-build
+## release-build: generates assets for public release
+release-build: clean linux-x64
+	@echo "Completed all tasks for release build"


### PR DESCRIPTION
- split `windows` recipe into `windows-x86` and `windows-x64` keeping `windows` as a wrapper for both
- split `linux` recipe into `linux-x86` and `linux-x64` keeping `linux` as a wrapper for both
- create new `release-build` recipe as a wrapper for recipes used to generate assets for public release

fixes GH-337