### PR TITLE
Fix potential VM MOID retrieval nil pointer derefs

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -337,7 +337,7 @@ func FilterVMByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, erro
 
 	for _, vm := range vms {
 		// return match, if available
-		if vm.Summary.Vm.Value == vmID {
+		if vm.Self.Value == vmID {
 			return vm, nil
 		}
 	}
@@ -478,10 +478,10 @@ func dedupeVMs(vmsList []mo.VirtualMachine) []mo.VirtualMachine {
 	seen := make(map[string]struct{}, len(vmsList))
 	j := 0
 	for _, vm := range vmsList {
-		if _, ok := seen[vm.Summary.Vm.Value]; ok {
+		if _, ok := seen[vm.Self.Value]; ok {
 			continue
 		}
-		seen[vm.Summary.Vm.Value] = struct{}{}
+		seen[vm.Self.Value] = struct{}{}
 		vmsList[j] = vm
 		j++
 	}


### PR DESCRIPTION
## Overview

Update functions in the `internal/vsphere` package:

- `FilterVMByID`
- `dedupeVMs`

Replace retrieval of a VM's MOID/MoRef via the `Summary.Vm` field (`*types.ManagedObjectReference`) which have the potential for a nil pointer dereference with `Self.Value` from the embedded `mo.ManagedEntity`.

## References

- fixes GH-358
- fixes GH-359
- https://pkg.go.dev/github.com/vmware/govmomi@v0.26.1/vim25/mo#VirtualMachine
  - https://pkg.go.dev/github.com/vmware/govmomi@v0.26.1/vim25/mo#ManagedEntity
    - https://pkg.go.dev/github.com/vmware/govmomi@v0.26.1/vim25/mo#ExtensibleManagedObject.Self
      - https://pkg.go.dev/github.com/vmware/govmomi@v0.26.1/vim25/types#ManagedObjectReference
