### PR TITLE
List number of VMs on datastore, powerstate

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -196,6 +196,10 @@ func main() {
 		Str("datastore_storage_remaining", units.ByteSize(dsUsage.StorageRemaining).String()).
 		Int("datastore_critical_threshold", dsUsage.CriticalThreshold).
 		Int("datastore_warning_threshold", dsUsage.WarningThreshold).
+		Int("vms", len(dsUsage.VMs)).
+		Int("vms_powered_off", dsUsage.VMs.NumVMsPoweredOff()).
+		Int("vms_powered_on", dsUsage.VMs.NumVMsPoweredOn()).
+		Int("datastore_warning_threshold", dsUsage.WarningThreshold).
 		Msg("Datastore usage summary")
 
 	log.Debug().Msg("Compiling Performance Data details")


### PR DESCRIPTION
For the `LongServiceOutput` section:

- Provide total count as part of datastore summary
- Split list of VMs into powered on, powered off sections
- Log total VMs, powered on count, powered off count

For the `ServiceOutput` (aka, "one line summary") section:

- Note total number of VMs on datastore

fixes GH-361