### PR TITLE
Skip eval of powered off VMs without running Tools

### DIFF
--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -204,7 +204,10 @@ func main() {
 		Msg("Filtered VMs")
 
 	log.Debug().Msg("Filter VMs to those with VMware Tools issues")
-	vmsWithIssues := vsphere.FilterVMsWithToolsIssues(filteredVMs)
+	if cfg.PoweredOff {
+		log.Debug().Msg("Ignore powered off VMs with Tools status of toolsNotRunning")
+	}
+	vmsWithIssues := vsphere.FilterVMsWithToolsIssues(filteredVMs, cfg.PoweredOff)
 
 	if len(vmsWithIssues) > 0 {
 


### PR DESCRIPTION
VMs with a VMware Tools status of `toolsNotRunning` IS problematic for powered on VMs, but not for powered off VMs as this is the expected status. This commit updates the `vsphere.FilterVMsWithToolsIssues()` function to ignore VMs in this state.

Any powered off VMs with other VMware Tools statuses are still evaluated as before.

NOTE: There are edge cases not currently handled by these changes. See GH-366 for details.

fixes GH-365
refs GH-366