### PR TITLE
Evaluate suspended VMs as powered off VMs

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -406,9 +406,6 @@ func FilterVMsByPowerState(vms []mo.VirtualMachine, includePoweredOff bool) []mo
 
 	for _, vm := range vms {
 		switch {
-		// case includePoweredOff && vm.Guest.ToolsStatus != types.VirtualMachineToolsStatusToolsOk:
-		// 	vmsWithIssues = append(vmsWithIssues, vm)
-
 		case vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn:
 			filteredVMs = append(filteredVMs, vm)
 


### PR DESCRIPTION
Update the `vsphere.FilterVMsByPowerState()` func:

- consider suspended VMs to be powered off
- include suspended VMs if flag was given to return powered off VMs (for further evaluation)

fixes GH-374