### PR TITLE
Update `check_vmware_host_*` plugins to log host VMs

### DIFF
--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/atc0005/go-nagios"
 
@@ -172,16 +173,16 @@ func main() {
 		Int("host_system_warning_threshold", hsUsage.WarningThreshold).
 		Msg("HostSystem CPU usage summary")
 
-	log.Debug().Msg("Retrieving VMs for host")
+	log.Debug().Msg("Retrieving VMs on host")
 	hsVMs, hsVMsFetchErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, hostSystem.ManagedEntity)
 	if hsVMsFetchErr != nil {
 		log.Error().Err(hsVMsFetchErr).Msg(
-			"error retrieving VirtualMachines from host",
+			"error retrieving VirtualMachines on host",
 		)
 
 		nagiosExitState.LastError = hsVMsFetchErr
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
-			"%s: Error retrieving VirtualMachines from host %q",
+			"%s: Error retrieving VirtualMachines on host %q",
 			nagios.StateCRITICALLabel,
 			cfg.HostSystemName,
 		)
@@ -189,6 +190,10 @@ func main() {
 
 		return
 	}
+
+	log.Debug().
+		Str("vms_on_host", strings.Join(vsphere.VMNames(hsVMs), ", ")).
+		Msg("Virtual Machines on host")
 
 	log.Debug().Msg("Evaluating host CPU usage state")
 	switch {

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/atc0005/go-nagios"
 	"github.com/vmware/govmomi/units"
@@ -173,16 +174,16 @@ func main() {
 		Int("host_system_warning_threshold", hsUsage.WarningThreshold).
 		Msg("HostSystem memory usage summary")
 
-	log.Debug().Msg("Retrieving VMs for host")
+	log.Debug().Msg("Retrieving VMs on host")
 	hsVMs, hsVMsFetchErr := vsphere.GetVMsFromContainer(ctx, c.Client, true, hostSystem.ManagedEntity)
 	if hsVMsFetchErr != nil {
 		log.Error().Err(hsVMsFetchErr).Msg(
-			"error retrieving VirtualMachines from host",
+			"error retrieving VirtualMachines on host",
 		)
 
 		nagiosExitState.LastError = hsVMsFetchErr
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
-			"%s: Error retrieving VirtualMachines from host %q",
+			"%s: Error retrieving VirtualMachines on host %q",
 			nagios.StateCRITICALLabel,
 			cfg.HostSystemName,
 		)
@@ -190,6 +191,10 @@ func main() {
 
 		return
 	}
+
+	log.Debug().
+		Str("vms_on_host", strings.Join(vsphere.VMNames(hsVMs), ", ")).
+		Msg("Virtual Machines on host")
 
 	log.Debug().Msg("Evaluating host memory usage state")
 	switch {


### PR DESCRIPTION
Log VMs associated with the host for troubleshooting purposes.

Tweak wording of nearby log messages to use "on" phrasing instead of "for" or "from" in an attempt to be consistent with `LongServiceOutput` phrasing.

- fixes GH-377
- fixes GH-378