### PR TITLE
Update filter func names to reflect plural source

### DIFF
--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -234,11 +234,11 @@ func GetDatastoreByName(ctx context.Context, c *vim25.Client, dsName string, dat
 
 }
 
-// FilterDatastoreByName accepts a collection of Datastores and a Datastore
+// FilterDatastoresByName accepts a collection of Datastores and a Datastore
 // name to filter against. An error is returned if the list of Datastores is
-// empty or if a match was not found. The matching Datastore is returned
-// along with the number of Datastores that were excluded.
-func FilterDatastoreByName(dss []mo.Datastore, dsName string) (mo.Datastore, int, error) {
+// empty or if a match was not found. The matching Datastore is returned along
+// with the number of Datastores that were excluded.
+func FilterDatastoresByName(dss []mo.Datastore, dsName string) (mo.Datastore, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -247,7 +247,7 @@ func FilterDatastoreByName(dss []mo.Datastore, dsName string) (mo.Datastore, int
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterDatastoreByName func.\n",
+			"It took %v to execute FilterDatastoresByName func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()
@@ -271,11 +271,11 @@ func FilterDatastoreByName(dss []mo.Datastore, dsName string) (mo.Datastore, int
 
 }
 
-// FilterDatastoreByID receives a collection of Datastores and a Datastore ID
+// FilterDatastoresByID receives a collection of Datastores and a Datastore ID
 // to filter against. An error is returned if the list of Datastores is empty
 // or if a match was not found. The matching Datastore is returned along with
 // the number of Datastores that were excluded.
-func FilterDatastoreByID(dss []mo.Datastore, dsID string) (mo.Datastore, int, error) {
+func FilterDatastoresByID(dss []mo.Datastore, dsID string) (mo.Datastore, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -284,7 +284,7 @@ func FilterDatastoreByID(dss []mo.Datastore, dsID string) (mo.Datastore, int, er
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterDatastoreByID func.\n",
+			"It took %v to execute FilterDatastoresByID func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -306,7 +306,7 @@ func (hdi HostToDatastoreIndex) ValidateVirtualMachinePairings(
 					)
 
 					dsID := dsIDLookupErr.DatastoreID
-					datastore, _, filterErr := FilterDatastoreByID(allDatastores, dsID)
+					datastore, _, filterErr := FilterDatastoresByID(allDatastores, dsID)
 					if filterErr != nil {
 
 						// This is our second attempt to lookup the

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -219,11 +219,11 @@ func GetHostSystemByName(ctx context.Context, c *vim25.Client, hsName string, da
 
 }
 
-// FilterHostSystemByName accepts a collection of HostSystems and a HostSystem
-// name to filter against. An error is returned if the list of HostSystems is
-// empty or if a match was not found. The matching HostSystem is returned
-// along with the number of HostSystems that were excluded.
-func FilterHostSystemByName(hss []mo.HostSystem, hsName string) (mo.HostSystem, int, error) {
+// FilterHostSystemsByName accepts a collection of HostSystems and a
+// HostSystem name to filter against. An error is returned if the list of
+// HostSystems is empty or if a match was not found. The matching HostSystem
+// is returned along with the number of HostSystems that were excluded.
+func FilterHostSystemsByName(hss []mo.HostSystem, hsName string) (mo.HostSystem, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -232,7 +232,7 @@ func FilterHostSystemByName(hss []mo.HostSystem, hsName string) (mo.HostSystem, 
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterHostSystemByName func.\n",
+			"It took %v to execute FilterHostSystemsByName func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()
@@ -256,11 +256,11 @@ func FilterHostSystemByName(hss []mo.HostSystem, hsName string) (mo.HostSystem, 
 
 }
 
-// FilterHostSystemByID receives a collection of HostSystems and a HostSystem
+// FilterHostSystemsByID receives a collection of HostSystems and a HostSystem
 // ID to filter against. An error is returned if the list of HostSystems is
 // empty or if a match was not found. The matching HostSystem is returned
 // along with the number of HostSystems that were excluded.
-func FilterHostSystemByID(hss []mo.HostSystem, hsID string) (mo.HostSystem, int, error) {
+func FilterHostSystemsByID(hss []mo.HostSystem, hsID string) (mo.HostSystem, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -269,7 +269,7 @@ func FilterHostSystemByID(hss []mo.HostSystem, hsID string) (mo.HostSystem, int,
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterHostSystemByID func.\n",
+			"It took %v to execute FilterHostSystemsByID func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()

--- a/internal/vsphere/networks.go
+++ b/internal/vsphere/networks.go
@@ -80,11 +80,11 @@ func GetNetworkByName(ctx context.Context, c *vim25.Client, netName string, data
 
 }
 
-// FilterNetworkByName accepts a collection of Networks and a Network name to
+// FilterNetworksByName accepts a collection of Networks and a Network name to
 // filter against. An error is returned if the list of Networks is empty or if
 // a match was not found. The matching Network is returned along with the
 // number of Networks that were excluded.
-func FilterNetworkByName(nets []mo.Network, netName string) (mo.Network, int, error) {
+func FilterNetworksByName(nets []mo.Network, netName string) (mo.Network, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -93,7 +93,7 @@ func FilterNetworkByName(nets []mo.Network, netName string) (mo.Network, int, er
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterNetworkByName func.\n",
+			"It took %v to execute FilterNetworksByName func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()
@@ -117,11 +117,11 @@ func FilterNetworkByName(nets []mo.Network, netName string) (mo.Network, int, er
 
 }
 
-// FilterNetworkByID receives a collection of Networks and a Network ID to
+// FilterNetworksByID receives a collection of Networks and a Network ID to
 // filter against. An error is returned if the list of Networks is empty or if
 // a match was not found. The matching Network is returned along with the
 // number of Networks that were excluded.
-func FilterNetworkByID(nets []mo.Network, netID string) (mo.Network, int, error) {
+func FilterNetworksByID(nets []mo.Network, netID string) (mo.Network, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -130,7 +130,7 @@ func FilterNetworkByID(nets []mo.Network, netID string) (mo.Network, int, error)
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterNetworkByID func.\n",
+			"It took %v to execute FilterNetworksByID func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -238,7 +238,7 @@ func GetVMsFromDatastore(ctx context.Context, c *vim25.Client, ds mo.Datastore, 
 	}
 
 	for i := range ds.Vm {
-		vm, _, err := FilterVMByID(allVMs, ds.Vm[i].Value)
+		vm, _, err := FilterVMsByID(allVMs, ds.Vm[i].Value)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to retrieve VM for VM ID %s: %w",
@@ -286,11 +286,12 @@ func GetVMByName(ctx context.Context, c *vim25.Client, vmName string, datacenter
 
 }
 
-// FilterVMByName accepts a collection of VirtualMachines and a VirtualMachine
-// name to filter against. An error is returned if the list of VirtualMachines
-// is empty or if a match was not found. The matching VirtualMachine is
-// returned along with the number of VirtualMachines that were excluded.
-func FilterVMByName(vms []mo.VirtualMachine, vmName string) (mo.VirtualMachine, int, error) {
+// FilterVMsByName accepts a collection of VirtualMachines and a
+// VirtualMachine name to filter against. An error is returned if the list of
+// VirtualMachines is empty or if a match was not found. The matching
+// VirtualMachine is returned along with the number of VirtualMachines that
+// were excluded.
+func FilterVMsByName(vms []mo.VirtualMachine, vmName string) (mo.VirtualMachine, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -299,7 +300,7 @@ func FilterVMByName(vms []mo.VirtualMachine, vmName string) (mo.VirtualMachine, 
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterVMByName func.\n",
+			"It took %v to execute FilterVMsByName func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()
@@ -323,11 +324,11 @@ func FilterVMByName(vms []mo.VirtualMachine, vmName string) (mo.VirtualMachine, 
 
 }
 
-// FilterVMByID receives a collection of VirtualMachines and a VirtualMachine
+// FilterVMsByID receives a collection of VirtualMachines and a VirtualMachine
 // ID to filter against. An error is returned if the list of VirtualMachines
 // is empty or if a match was not found. The matching VirtualMachine is
 // returned along with the number of VirtualMachines that were excluded.
-func FilterVMByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, int, error) {
+func FilterVMsByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, int, error) {
 
 	funcTimeStart := time.Now()
 
@@ -336,7 +337,7 @@ func FilterVMByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, int,
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute FilterVMByID func.\n",
+			"It took %v to execute FilterVMsByID func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()


### PR DESCRIPTION
Update `FilterXByY()` funcs that return a single match to emphasize that `X` is a collection to be filtered, not a single
value.

fixes GH-380