### PR TITLE
check_vmware_datastore | Make VM list conditional

### DIFF
--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -408,6 +408,11 @@ func DatastoreUsageReport(
 
 	printVMSummary := func(powerState types.VirtualMachinePowerState) {
 
+		// Skip efforts to list VM summary details if there is nothing to show.
+		if len(dsUsageSummary.VMs) == 0 {
+			return
+		}
+
 		var powerStateVMs int
 		switch powerState {
 		case types.VirtualMachinePowerStatePoweredOn:


### PR DESCRIPTION
Only attempt to display summary VM list if there are VMs residing on the datastore.

fixes GH-385