### PR TITLE
Support retrieving VMs from VirtualApps

### DIFF
--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -38,6 +38,7 @@ const (
 	MgObjRefTypeResourcePool    string = "ResourcePool"
 	MgObjRefTypeHostSystem      string = "HostSystem"
 	MgObjRefTypeVirtualMachine  string = "VirtualMachine"
+	MgObjRefTypeVirtualApp      string = "VirtualApp"
 )
 
 // used with snapshots reports that provide Long Service Output

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -156,8 +156,8 @@ func GetVMs(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo.Virtua
 }
 
 // GetVMsFromContainer receives one or many ManagedEntity values for Folder,
-// Datacenter, ComputeResource, ResourcePool, or HostSystem types and returns
-// a list of VirtualMachine object references.
+// Datacenter, ComputeResource, ResourcePool, VirtualApp or HostSystem types
+// and returns a list of VirtualMachine object references.
 //
 // The propsSubset boolean value indicates whether a subset of properties per
 // VirtualMachine are retrieved. If requested, a subset of all available


### PR DESCRIPTION
Expand type checks to allow using a `VirtualApp` with `ContainerViews` in order to retrieve VirtualMachines.

From what I understand (and what testing confirms), the `VirtualApp` type inherits all of the properties of a `ResourcePool`, allowing us to retrieve VMs from them as we would a normal `ResourcePool` type.

fixes GH-397