### PR TITLE
Note type of container for retrieved VMs

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -182,6 +182,12 @@ func GetVMsFromContainer(ctx context.Context, c *vim25.Client, propsSubset bool,
 
 	for _, obj := range objs {
 
+		logger.Printf(
+			"Retrieving VirtualMachines from object %q of type %q",
+			obj.Name,
+			obj.Self.Type,
+		)
+
 		var vmsFromContainer []mo.VirtualMachine
 
 		err := getObjects(ctx, c, &vmsFromContainer, obj.Reference(), propsSubset)


### PR DESCRIPTION
Add debug log message to `vsphere.GetVMsFromContainer()` for troubleshooting purposes.