### PR TITLE
Clarify intent of `timeout` flag

### DIFF
--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -70,6 +70,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -65,6 +65,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -67,6 +67,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -67,6 +67,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -71,6 +71,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -66,6 +66,8 @@ func main() {
 		vsphere.EnableLogging()
 	}
 
+	// Set context deadline equal to user-specified timeout value for plugin
+	// runtime/execution.
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout())
 	defer cancel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -341,9 +341,8 @@ type Config struct {
 	// Port is the TCP port used by the certifcate-enabled service.
 	Port int
 
-	// timeout is the number of seconds allowed before the connection attempt
-	// to a standalone ESXi host or vCenter instance is abandoned and an error
-	// returned.
+	// timeout is the value in seconds allowed before a plugin execution
+	// attempt is abandoned and an error returned.
 	timeout int
 
 	// VCPUsAllocatedWarning specifies the percentage of vCPUs allocation (as

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -16,7 +16,7 @@ const (
 	serverFlagHelp                                  string = "The fully-qualified domain name or IP Address of the remote ESXi host or vCenter instance."
 	trustCertFlagHelp                               string = "Whether the certificate should be trusted as-is without validation. WARNING: TLS is susceptible to man-in-the-middle attacks if enabling this option."
 	portFlagHelp                                    string = "TCP port of the remote ESXi host or vCenter instance. This is usually 443 (HTTPS)."
-	timeoutConnectFlagHelp                          string = "Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned."
+	timeoutPluginRuntimeFlagHelp                    string = "Timeout value in seconds allowed before a plugin execution attempt is abandoned and an error returned."
 	brandingFlagHelp                                string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
 	usernameFlagHelp                                string = "Username with permission to access specified ESXi host or vCenter instance."
 	passwordFlagHelp                                string = "Password used to login to ESXi host or vCenter instance."
@@ -131,8 +131,8 @@ const (
 	defaultVCPUsMaxAllowed               int = 0
 	defaultResourcePoolsMemoryMaxAllowed int = 0
 
-	// Default timeout (in seconds) used when connecting to a remote server
-	defaultConnectTimeout int = 10
+	// Default timeout (in seconds) used for plugin runtime
+	defaultPluginRuntimeTimeout int = 10
 
 	defaultCustomAttributeName string = ""
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -277,8 +277,8 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 	flag.IntVar(&c.Port, "p", defaultPort, portFlagHelp+" (shorthand)")
 	flag.IntVar(&c.Port, "port", defaultPort, portFlagHelp)
 
-	flag.IntVar(&c.timeout, "t", defaultConnectTimeout, timeoutConnectFlagHelp)
-	flag.IntVar(&c.timeout, "timeout", defaultConnectTimeout, timeoutConnectFlagHelp)
+	flag.IntVar(&c.timeout, "t", defaultPluginRuntimeTimeout, timeoutPluginRuntimeFlagHelp)
+	flag.IntVar(&c.timeout, "timeout", defaultPluginRuntimeTimeout, timeoutPluginRuntimeFlagHelp)
 
 	flag.StringVar(&c.LoggingLevel, "ll", defaultLogLevel, logLevelFlagHelp)
 	flag.StringVar(&c.LoggingLevel, "log-level", defaultLogLevel, logLevelFlagHelp)

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -12,9 +12,9 @@ import (
 	"time"
 )
 
-// Timeout converts the user-specified connection timeout value in
-// seconds to an appropriate time duration value for use with setting
-// initial connection attempt timeout value.
+// Timeout converts the user-specified plugin runtime/execution timeout value
+// in seconds to an appropriate time duration value for use with setting
+// context deadline value.
 func (c Config) Timeout() time.Duration {
 	return time.Duration(c.timeout) * time.Second
 }

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -79,7 +79,7 @@ func (c *Config) setupLogging(pluginType PluginType) error {
 		Str("version", Version()).
 		Str("logging_level", c.LoggingLevel).
 		Str("plugin_type", pluginTypeLabel(pluginType)).
-		Str("connection_timeout", c.Timeout().String()).
+		Str("plugin_timeout", c.Timeout().String()).
 		Str("username", c.Username).
 		Str("user_domain", c.Domain).
 		Bool("trust_cert", c.TrustCert).


### PR DESCRIPTION
Update existing, add new doc comments to note that the
existing `timeout` flag and settings are specific to
plugin runtime/execution and not the initial connection
attempt to an ESXi server or vCenter instance.

Previously, the documentation noted plugin runtime/execution
while the doc comments noted connection timeout. This was
confusing and inconsistent.

fixes GH-414