### PR TITLE
Optional state reload before checking disk consolidation status

### DIFF
--- a/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
@@ -6,27 +6,54 @@
 # full license information.
 
 
-# Look at specific pools, exclude other pools
+# Look at specific pools, exclude other pools. Use existing (potentially
+# stale) state data for evaluation of disk consolidation status instead of
+# triggering (potentially expensive) reload/refresh of state data.
 define command{
     command_name    check_vmware_disk_consolidation_include_pools
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
     }
 
-# Look at specific pools, exclude other pools, exclude list of VMs
+# Look at specific pools, exclude other pools, exclude list of VMs. Use
+# existing (potentially stale) state data for evaluation of disk consolidation
+# status instead of triggering (potentially expensive) reload/refresh of state
+# data.
 define command{
     command_name    check_vmware_disk_consolidation_include_pools_exclude_vms
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
-# Look at all pools, all VMs. This variation of the command is most useful for
-# environments where all VMs are monitored equally.
+# Look at all pools, all VMs.  Use existing (potentially stale) state data for
+# evaluation of disk consolidation status instead of triggering (potentially
+# expensive) reload/refresh of state data.
+#
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally and no filtering based on pool membership or VM name
+# is needed.
 define command{
     command_name    check_vmware_disk_consolidation
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
     }
 
-# Look at all pools, exclude list of VMs
+# Look at all pools, exclude list of VMs.  Use existing (potentially stale)
+# state data for evaluation of disk consolidation status instead of triggering
+# (potentially expensive) reload/refresh of state data.
 define command{
     command_name    check_vmware_disk_consolidation_exclude_vms
     command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --ignore-vm '$ARG4$' --trust-cert --log-level info
+    }
+
+# Look at all pools, all VMs, trigger potentially expensive reload operation
+# on each evaluated VM.
+#
+# This variation of the command is most useful for environments where all VMs
+# are monitored equally and where the time required to reload/refresh data
+# data for each VM is acceptable.
+#
+# The tradeoff in having current state data comes at the cost of increased
+# execution time. If this proves too expensive for your environment, you may
+# wish to schedule a job on the cluster to handle refreshing state data.
+define command{
+    command_name    check_vmware_disk_consolidation_trigger_reload
+    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info --trigger-reload --timeout 110
     }

--- a/doc.go
+++ b/doc.go
@@ -42,7 +42,7 @@ hosts or vCenter instances).
 
 • Virtual Machine (power cycle) uptime
 
-• Virtual Machine disk consolidation status
+• Virtual Machine disk consolidation status (with optional forced refresh of Virtual Machine state data)
 
 • Virtual Machine interactive question status
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -449,6 +449,11 @@ type Config struct {
 	// alarms are evaluated in addition to unacknowledged ones.
 	EvaluateAcknowledgedAlarms bool
 
+	// TriggerReloadStateData indicates whether the state data for evaluated
+	// objects (e.g., VirtualMachines) will be reloaded/refreshed prior to
+	// evaluation of specific properties.
+	TriggerReloadStateData bool
+
 	// Whether the certificate should be trusted as-is without validation.
 	TrustCert bool
 

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -75,6 +75,7 @@ const (
 	excludedAlarmStatusesFlagHelp                   string = "If specified, triggered alarms will only be evaluated if the alarm status (e.g., \"yellow\") DOES NOT case-insensitively match one of the specified keywords (e.g., \"yellow\" or \"warning\") and is not explicitly excluded by another filter in the pipeline; while multiple explicit inclusions are allowed, explicit exclusions have precedence over explicit inclusions and will exclude the triggered alarm from further evaluation."
 	includedAlarmEntityResourcePoolsFlagHelp        string = "If specified, triggered alarms will only be evaluated if the associated entity is part of one of the specified Resource Pools (case-insensitive match on the name) and is not explicitly excluded by another filter in the pipeline; while multiple explicit inclusions are allowed, explicit exclusions have precedence over explicit inclusions and will exclude the triggered alarm from further evaluation."
 	excludedAlarmEntityResourcePoolsFlagHelp        string = "If specified, triggered alarms will only be evaluated if the associated entity is NOT part of one of the specified Resource Pools (case-insensitive match on the name) and is not explicitly excluded by another filter in the pipeline; while multiple explicit inclusions are allowed, explicit exclusions have precedence over explicit inclusions and will exclude the triggered alarm from further evaluation."
+	triggerReloadStateDataFlagHelp                  string = "Toggles (potentially expensive) reload/refresh of state data for evaluated vSphere objects. This is disabled by default."
 )
 
 // Default flag settings if not overridden by user input
@@ -91,6 +92,7 @@ const (
 	defaultDisplayVersionAndExit        bool   = false
 	defaultPoweredOff                   bool   = false
 	defaultEvaluateAcknowledgedAlarms   bool   = false
+	defaultTriggerReloadStateData       bool   = false
 	defaultVCPUsAllocatedCritical       int    = 100
 	defaultVCPUsAllocatedWarning        int    = 95
 	defaultIgnoreMissingCustomAttribute bool   = false

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -105,6 +105,7 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.Var(&c.IncludedResourcePools, "include-rp", vmIncludedResourcePoolsFlagHelp)
 		flag.Var(&c.ExcludedResourcePools, "exclude-rp", vmExcludedResourcePoolsFlagHelp)
 		flag.Var(&c.IgnoredVMs, "ignore-vm", ignoreVMsFlagHelp)
+		flag.BoolVar(&c.TriggerReloadStateData, "trigger-reload", defaultTriggerReloadStateData, triggerReloadStateDataFlagHelp)
 
 		// NOTE: This plugin is hard-coded to evaluate powered off and powered
 		// on VMs equally. I'm not sure whether ignoring powered off VMs by

--- a/internal/vsphere/methods.go
+++ b/internal/vsphere/methods.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package vsphere
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TriggerEntityStateReload accepts a context, a client and a collection of
+// ManagedEntity values whose state should be reloaded. This function is used
+// when we need to ensure that we are working with the very latest state data
+// for a vSphere object.
+func TriggerEntityStateReload(ctx context.Context, c *vim25.Client, entities []mo.ManagedEntity) error {
+
+	// https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.ManagedEntity.html#reload
+	// https://pkg.go.dev/github.com/vmware/govmomi@v0.27.0/vim25/methods#Reload
+
+	funcTimeStart := time.Now()
+
+	defer func(entities []mo.ManagedEntity) {
+		logger.Printf(
+			"It took %v to execute TriggerEntityStateReload func (for %d entities).\n",
+			time.Since(funcTimeStart),
+			len(entities),
+		)
+	}(entities)
+
+	for _, entity := range entities {
+
+		req := types.Reload{
+			This: entity.Self,
+		}
+
+		logger.Printf(
+			"Triggering reload for entity %s of type %s with id %s",
+			entity.Name,
+			entity.Self.Type,
+			entity.Self.Value,
+		)
+
+		reloadTimeStart := time.Now()
+		_, err := methods.Reload(ctx, c, &req)
+		if err != nil {
+			return err
+		}
+
+		logger.Printf(
+			"It took %v to trigger state reload for entity %s",
+			time.Since(reloadTimeStart),
+			entity.Name,
+		)
+
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
- Move disk consolidation needed state filtering logic to
  `vsphere.FilterVMsByDiskConsolidationState()`

- Add `vsphere.TriggerEntityStateReload()` function to reload
  the current state for provided ManagedEntity values
  - We use this to ensure that the `vm.Runtime.ConsolidationNeeded`
    field has the most current data for evaluation

- Add `--trigger-reload` flag to allow optional state
  reload/refresh before evaluating disk consolidation status

- Documentation updates to reflect new optional state reload
  support

- Update contrib command definition file for plugin to
  illustrate use of new flag, document benefits (fresh state
  data) and shortcomings (plugin runtime increase) of using
  the new flag

fixes GH-278
fixes GH-293