### PR TITLE
Fix UoM in `(vsphere.CPUSpeed).String()` method

### DIFF
--- a/internal/vsphere/cpu.go
+++ b/internal/vsphere/cpu.go
@@ -42,9 +42,9 @@ const (
 func (cpu CPUSpeed) String() string {
 	switch {
 	case cpu >= YHz:
-		return fmt.Sprintf("%.1f EHz", float64(cpu)/YHz)
+		return fmt.Sprintf("%.1f YHz", float64(cpu)/YHz)
 	case cpu >= ZHz:
-		return fmt.Sprintf("%.1f EHz", float64(cpu)/ZHz)
+		return fmt.Sprintf("%.1f ZHz", float64(cpu)/ZHz)
 	case cpu >= EHz:
 		return fmt.Sprintf("%.1f EHz", float64(cpu)/EHz)
 	case cpu >= PHz:


### PR DESCRIPTION
Fix incorrect EHz UoM emitted for YHz and ZHz values.

fixes GH-424