### PR TITLE
Fix potential nil pointer deref in Host HW usage

### DIFF
--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -164,11 +164,23 @@ func main() {
 	log.Debug().Msg("Successfully retrieved host by name")
 
 	log.Debug().Msg("Generating host CPU usage summary")
-	hsUsage := vsphere.NewHostSystemCPUUsageSummary(
+	hsUsage, hsUsageErr := vsphere.NewHostSystemCPUUsageSummary(
 		hostSystem,
 		cfg.HostSystemCPUUseCritical,
 		cfg.HostSystemCPUUseWarning,
 	)
+	if hsUsageErr != nil {
+		log.Error().Err(hsUsageErr).Msg("error creating host CPU usage summary")
+
+		nagiosExitState.LastError = hsUsageErr
+		nagiosExitState.ServiceOutput = fmt.Sprintf(
+			"%s: Error creating host CPU usage summary",
+			nagios.StateCRITICALLabel,
+		)
+		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
+
+		return
+	}
 
 	log.Debug().
 		Str("host_system_name", hostSystem.Name).


### PR DESCRIPTION
Modify `vsphere.NewHostSystemCPUUsageSummary()` function signature to return error if `HostSystem.Summary.Hardware` property is unavailable. Update plugin code to handle error condition.

fixes GH-425