### PR TITLE
Fix potential nil pointer deref in Host mem usage

### DIFF
--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -159,11 +159,23 @@ func main() {
 	log.Debug().Msg("Successfully retrieved host by name")
 
 	log.Debug().Msg("Generating host memory usage summary")
-	hsUsage := vsphere.NewHostSystemMemoryUsageSummary(
+	hsUsage, hsUsageErr := vsphere.NewHostSystemMemoryUsageSummary(
 		hostSystem,
 		cfg.HostSystemMemoryUseCritical,
 		cfg.HostSystemMemoryUseWarning,
 	)
+	if hsUsageErr != nil {
+		log.Error().Err(hsUsageErr).Msg("error creating host memory usage summary")
+
+		nagiosExitState.LastError = hsUsageErr
+		nagiosExitState.ServiceOutput = fmt.Sprintf(
+			"%s: Error creating host memory usage summary",
+			nagios.StateCRITICALLabel,
+		)
+		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
+
+		return
+	}
 
 	log.Debug().
 		Str("host_system_name", hostSystem.Name).

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -75,8 +75,16 @@ type HostSystemCPUSummary struct {
 
 // NewHostSystemMemoryUsageSummary receives a HostSystem and generates summary
 // information used to determine if usage levels have crossed user-specified
-// thresholds.
-func NewHostSystemMemoryUsageSummary(hs mo.HostSystem, criticalThreshold int, warningThreshold int) HostSystemMemorySummary {
+// thresholds. If required information is not accessible (e.g., permissions
+// issue for service account) an error is returned indicating this.
+func NewHostSystemMemoryUsageSummary(hs mo.HostSystem, criticalThreshold int, warningThreshold int) (HostSystemMemorySummary, error) {
+
+	if hs.Summary.Hardware == nil {
+		return HostSystemMemorySummary{}, fmt.Errorf(
+			"error creating HostSystemMemorySummary: %w",
+			ErrHostSystemHardwarePropertiesUnavailable,
+		)
+	}
 
 	// total memory in bytes
 	memoryTotal := hs.Hardware.MemorySize
@@ -101,13 +109,14 @@ func NewHostSystemMemoryUsageSummary(hs mo.HostSystem, criticalThreshold int, wa
 		WarningThreshold:       warningThreshold,
 	}
 
-	return hsUsage
+	return hsUsage, nil
 
 }
 
 // NewHostSystemCPUUsageSummary receives a HostSystem and generates summary
 // information used to determine if usage levels have crossed user-specified
-// thresholds.
+// thresholds. If required information is not accessible (e.g., permissions
+// issue for service account) an error is returned indicating this.
 func NewHostSystemCPUUsageSummary(hs mo.HostSystem, criticalThreshold int, warningThreshold int) (HostSystemCPUSummary, error) {
 
 	if hs.Summary.Hardware == nil {


### PR DESCRIPTION
Modify `vsphere.NewHostSystemMemoryUsageSummary()` function signature to return error if `HostSystem.Summary.Hardware` property is unavailable. Update plugin code to handle error condition.

fixes GH-430