### PR TITLE
Fix incorrect UoM for host memory plugin

### DIFF
--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -247,7 +247,7 @@ func main() {
 		{
 			Label:             "memory_total",
 			Value:             fmt.Sprintf("%d", hsUsage.MemoryTotal),
-			UnitOfMeasurement: "Hz",
+			UnitOfMeasurement: "B",
 		},
 		{
 			Label:             "memory_remaining",


### PR DESCRIPTION
Evidently a bad copy/paste/modify operation.

fixes GH-436