### PR TITLE
Add `*_used` Performance Data metric

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -219,6 +219,13 @@ func main() {
 			Crit:              fmt.Sprintf("%d", dsUsage.CriticalThreshold),
 		},
 		{
+			Label:             "datastore_storage_used",
+			Value:             fmt.Sprintf("%d", dsUsage.StorageUsed),
+			UnitOfMeasurement: "B",
+			Max:               fmt.Sprintf("%d", dsUsage.StorageTotal),
+			Min:               "0",
+		},
+		{
 			Label:             "datastore_storage_remaining",
 			Value:             fmt.Sprintf("%d", dsUsage.StorageRemaining),
 			UnitOfMeasurement: "B",

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -249,6 +249,13 @@ func main() {
 			UnitOfMeasurement: "Hz",
 		},
 		{
+			Label:             "cpu_used",
+			Value:             fmt.Sprintf("%.2f", hsUsage.CPUUsed),
+			UnitOfMeasurement: "Hz",
+			Max:               fmt.Sprintf("%.2f", hsUsage.CPUTotal),
+			Min:               "0",
+		},
+		{
 			Label:             "cpu_remaining",
 			Value:             fmt.Sprintf("%.2f", hsUsage.CPURemaining),
 			UnitOfMeasurement: "Hz",

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -250,6 +250,13 @@ func main() {
 			UnitOfMeasurement: "B",
 		},
 		{
+			Label:             "memory_used",
+			Value:             fmt.Sprintf("%d", hsUsage.MemoryUsed),
+			UnitOfMeasurement: "B",
+			Max:               fmt.Sprintf("%d", hsUsage.MemoryTotal),
+			Min:               "0",
+		},
+		{
 			Label:             "memory_remaining",
 			Value:             fmt.Sprintf("%d", hsUsage.MemoryRemaining),
 			UnitOfMeasurement: "B",


### PR DESCRIPTION
Include this metric with the ones recently added for:

- `check_vmware_datastore`
- `check_vmware_host_cpu`
- `check_vmware_host_memory`

fixes GH-435