### PR TITLE
Avoid nil pointer deref in VM question report

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -1189,7 +1189,8 @@ func VMInteractiveQuestionReport(
 
 			var question string
 			switch {
-			case vm.Summary.Runtime.Question.Text != "":
+			case vm.Summary.Runtime.Question != nil &&
+				vm.Summary.Runtime.Question.Text != "":
 				question = vm.Summary.Runtime.Question.Text
 			default:
 				question = "unknown"


### PR DESCRIPTION
While the risk is low (this block evaluates a pre-filtered list), we first assert that we are not dealing with a nil pointer to `Runtime.Question` before attempting to retrieve the `Question` text value.

fixes GH-439