### PR TITLE
Hotfix incorrect metrics for snapshots age plugin

### DIFF
--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -265,8 +265,8 @@ func main() {
 
 	log.Debug().Msg("Compiling Performance Data details")
 
-	numVMsWithCriticalSnapshots, numCriticalSnapshots := snapshotSets.ExceedsAge(cfg.SnapshotsAgeCritical)
-	numVMsWithWarningSnapshots, numWarningSnapshots := snapshotSets.ExceedsAge(cfg.SnapshotsAgeWarning)
+	numVMsWithCriticalSnapshots, numCriticalSnapshots := snapshotSets.AgeCriticalSnapshots()
+	numVMsWithWarningSnapshots, numWarningSnapshots := snapshotSets.AgeWarningSnapshots()
 
 	pd := []nagios.PerformanceData{
 		{


### PR DESCRIPTION
Fix incorrect WARNING state metrics by filtering out CRITICAL
state values that are also being treated as WARNING state.

Track SnapshotThresholds internally within a SnapshotSummarySet
in order to avoid having to specify threshold values multiple
times.

Further refactoring is planned which should better handle
tracking the specific state of CRITICAL snapshots, allowing
only one of WARNING or CRITICAL instead of instead of assuming
that a snapshot set in CRITICAL state is also of a WARNING
state (since both thresholds have been crossed).

- fixes GH-449
- refs GH-451