### PR TITLE
Refactor snapshots plugins to track thresholds

### DIFF
--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -331,7 +331,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -339,7 +338,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -370,7 +368,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -378,7 +375,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -408,7 +404,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -416,7 +411,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -276,7 +276,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -284,7 +283,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -315,7 +313,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -323,7 +320,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -345,7 +341,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -353,7 +348,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -274,7 +274,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -282,7 +281,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -311,7 +309,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -319,7 +316,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -341,7 +337,6 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
-			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -349,7 +344,6 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
-			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,


### PR DESCRIPTION
Instead of attempting to track overall WARNING or CRITICAL states via
fields track crossing of thresholds instead and implement methods that
handle the state determination.

Summary of changes:

- update fields to explicitly note that we are tracking the crossing
  of thresholds instead of specific "final" state
  - e.g., `ageWarningState` becomes `ageWarningThresholdCrossed`

- update `IsWarningState()` and `IsCriticalState()` method variants to
  use available collection item methods to avoid repeating field
  evaluation logic

- update field evaluation logic for WARNING state methods to also look
  at CRITICAL state thresholds to prevent reporting CRITICAL states as
  also being WARNING states (primary focus of refactoring work)

- update summary/report funcs to drop requirement for
  SnapshotThresholds parameter, rely on first item in
  SnapshotSummarySets collection to provide those values

- simplify `(vsphere.SnapshotSummarySets).AgeWarningSnapshots()`
  method by using updated `IsAgeWarningState()` method logic instead
  of directly working with age thresholds and state counting

- fixes GH-451
- refs GH-449