### PR TITLE
Use package logger for error destroying view msg

### DIFF
--- a/internal/vsphere/datacenters.go
+++ b/internal/vsphere/datacenters.go
@@ -68,7 +68,7 @@ func ValidateDCs(ctx context.Context, c *vim25.Client, datacenters []string) err
 		// method when a view is no longer needed. This practice frees memory
 		// on the server.
 		if err := v.Destroy(ctx); err != nil {
-			fmt.Println("Error occurred while destroying view")
+			logger.Printf("Error occurred while destroying view: %s", err)
 		}
 	}()
 

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -267,7 +267,7 @@ func getObjects(ctx context.Context, c *vim25.Client, dst interface{}, objRef ty
 		// method when a view is no longer needed. This practice frees memory
 		// on the server.
 		if err := v.Destroy(ctx); err != nil {
-			fmt.Println("Error occurred while destroying view")
+			logger.Printf("Error occurred while destroying view: %s", err)
 		}
 	}()
 

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -67,7 +67,7 @@ func ValidateRPs(ctx context.Context, c *vim25.Client, includeRPs []string, excl
 		// method when a view is no longer needed. This practice frees memory
 		// on the server.
 		if err := v.Destroy(ctx); err != nil {
-			fmt.Println("Error occurred while destroying view")
+			logger.Printf("Error occurred while destroying view: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
Replace `fmt.Println()` used by deferred view `Destroy()` method anonymous func "wrapper" with package logger `Printf()` call that returns the existing message but also emits the returned error.

In short, send the message (now with additional info) to the location the package logger is configured to use. This effectively mutes the output unless debug logging is enabled.

fixes GH-462