### PR TITLE
Emit time (runtime) perf data for all exit points

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -37,6 +37,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -206,10 +219,8 @@ func main() {
 	log.Debug().Msg("Compiling Performance Data details")
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label:             "datastore_usage",
 			Value:             fmt.Sprintf("%.2f", dsUsage.StorageUsedPercent),

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -277,10 +290,8 @@ func main() {
 	log.Debug().Msg("Compiling Performance Data details")
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -39,6 +39,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -233,10 +246,8 @@ func main() {
 	log.Debug().Msg("Compiling Performance Data details")
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label:             "memory_usage",
 			Value:             fmt.Sprintf("%.2f", hsUsage.MemoryUsedPercent),

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -241,10 +254,8 @@ func main() {
 	log.Debug().Msg("Compiling Performance Data details")
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -270,10 +283,8 @@ func main() {
 	numSnapshots := snapshotSets.Snapshots()
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -270,10 +283,8 @@ func main() {
 	numSnapshots := snapshotSets.Snapshots()
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -270,10 +283,8 @@ func main() {
 	numSnapshots := snapshotSets.Snapshots()
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -38,6 +38,19 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
+	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	defer func(exitState *nagios.ExitState, start time.Time) {
+		runtimeMetric := nagios.PerformanceData{
+			Label: "time",
+			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+		}
+		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+			zlog.Error().
+				Err(err).
+				Msg("failed to add time (runtime) performance data metric")
+		}
+	}(&nagiosExitState, pluginStart)
+
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()
@@ -238,10 +251,8 @@ func main() {
 	log.Debug().Msg("Compiling Performance Data details")
 
 	pd := []nagios.PerformanceData{
-		{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(pluginStart).Milliseconds()),
-		},
+		// The `time` (runtime) metric is appended at plugin exit, so do not
+		// duplicate it here.
 		{
 			Label: "vms",
 			Value: fmt.Sprintf("%d", len(vms)),


### PR DESCRIPTION
Move the collection of the `time` (runtime) performance data metric to a deferred function so that it is provided for all (non-panic induced) exit points used by plugins.

Plugins updated:

- `check_vmware_datastore`
- `check_vmware_disk_consolidation`
- `check_vmware_host_cpu`
- `check_vmware_host_memory`
- `check_vmware_question`
- `check_vmware_snapshots_age`
- `check_vmware_snapshots_count`
- `check_vmware_snapshots_size`
- `check_vmware_tools`

fixes GH-461