### PR TITLE
Fix incorrect threshold refs in host memory plugin

### DIFF
--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -252,8 +252,8 @@ func main() {
 			Label:             "memory_usage",
 			Value:             fmt.Sprintf("%.2f", hsUsage.MemoryUsedPercent),
 			UnitOfMeasurement: "%",
-			Warn:              fmt.Sprintf("%d", cfg.HostSystemCPUUseWarning),
-			Crit:              fmt.Sprintf("%d", cfg.HostSystemCPUUseCritical),
+			Warn:              fmt.Sprintf("%d", cfg.HostSystemMemoryUseWarning),
+			Crit:              fmt.Sprintf("%d", cfg.HostSystemMemoryUseCritical),
 		},
 		{
 			Label:             "memory_total",


### PR DESCRIPTION
Complete the original copy/paste/modify work when adding perf data metrics to this plugin based on the host CPU plugin.

Thanks to @Byolock for reporting the bug.

fixes GH-468