### PR TITLE
Add & use `vsphere.AnnotateError()` to wrap errors

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -37,8 +37,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -48,6 +51,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,8 +52,11 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
-	}(&nagiosExitState, pluginStart)
 
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+	}(&nagiosExitState, pluginStart)
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
 	vsphere.DisableLogging()

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -38,8 +38,11 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer nagiosExitState.ReturnCheckResults()
 
-	// Track plugin runtime, emit this metric regardless of exit point/cause.
+	// Collect last minute details just before ending plugin execution.
 	defer func(exitState *nagios.ExitState, start time.Time) {
+
+		// Record plugin runtime, emit this metric regardless of exit
+		// point/cause.
 		runtimeMetric := nagios.PerformanceData{
 			Label: "time",
 			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
@@ -49,6 +52,10 @@ func main() {
 				Err(err).
 				Msg("failed to add time (runtime) performance data metric")
 		}
+
+		// Annotate errors (if applicable) with additional context to aid in
+		// troubleshooting.
+		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default

--- a/internal/vsphere/errors.go
+++ b/internal/vsphere/errors.go
@@ -1,0 +1,42 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package vsphere
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrRuntimeTimeoutReached indicates that plugin runtime exceeded specified
+// timeout value.
+var ErrRuntimeTimeoutReached = errors.New("plugin runtime exceeded specified timeout value")
+
+// AnnotateError is a helper function used to add additional human-readable
+// explanation for errors commonly emitted by dependencies. This function
+// receives an error, evaluates whether it contains specific errors in its
+// chain and then (potentially) appends additional details for later use. This
+// updated error chain is returned to the caller, preserving the original
+// wrapper error. The original error is returned unmodified if no annotations
+// were deemed necessary.
+func AnnotateError(err error) error {
+
+	switch {
+
+	case errors.Is(err, context.DeadlineExceeded):
+		return fmt.Errorf("%w: %s", err, ErrRuntimeTimeoutReached)
+
+	default:
+
+		// Return error unmodified if additional decoration isn't defined for the
+		// error type.
+		return err
+
+	}
+
+}


### PR DESCRIPTION
- add `vsphere.ErrRuntimeTimeoutReached` error to indicate that an
  error has occurred due to a plugin's runtime exceeding a specified
  timeout value
- add `vsphere.AnnotateError()` func to *potentially* wrap passed
  errors with additional context
  - initial use case is annotating the `context.DeadlineExceeded`
    error type with `vsphere.ErrRuntimeTimeoutReached` error details
- update plugins currently emitting perf data to use
  `vsphere.AnnotateError()` func in a deferred anonymous func to wrap
  `(nagios.ExitState).LastError`

The end result is that these plugins now provide all of the error
output details as before, but also additional details if a
`context.DeadlineExceeded` error occurs:

- `check_vmware_datastore`
- `check_vmware_disk_consolidation`
- `check_vmware_host_cpu`
- `check_vmware_host_memory`
- `check_vmware_question`
- `check_vmware_snapshots_age`
- `check_vmware_snapshots_count`
- `check_vmware_snapshots_size`
- `check_vmware_tools`

Other plugins in the project slated for perf data work will have these
same changes applied as part of that work.

While this commit represents a functioning collection of changes, but
is likely not the final form; it is likely that some of this behavior
will be moved to the `atc0005/go-nagios` project at some point in the
future.

fixes GH-463
