### PR TITLE
Explicitly provide thresholds to reporting funcs

### DIFF
--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -355,6 +355,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -362,6 +363,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -392,6 +394,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -399,6 +402,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -428,6 +432,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -435,6 +440,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsAgeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -359,6 +359,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -366,6 +367,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -400,6 +402,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -407,6 +410,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -436,6 +440,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -443,6 +448,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsCountReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -359,6 +359,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -366,6 +367,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -400,6 +402,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -407,6 +410,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,
@@ -434,6 +438,7 @@ func main() {
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateOKLabel,
 			snapshotSets,
+			snapshotThresholds,
 			filteredVMs,
 			resourcePools,
 		)
@@ -441,6 +446,7 @@ func main() {
 		nagiosExitState.LongServiceOutput = vsphere.SnapshotsSizeReport(
 			c.Client,
 			snapshotSets,
+			snapshotThresholds,
 			vms,
 			filteredVMs,
 			vmsWithSnapshots,

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1180,6 +1180,7 @@ func NewSnapshotSummarySet(
 func SnapshotsAgeOneLineCheckSummary(
 	stateLabel string,
 	snapshotSets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	evaluatedVMs []mo.VirtualMachine,
 	rps []mo.ResourcePool,
 ) string {
@@ -1192,11 +1193,6 @@ func SnapshotsAgeOneLineCheckSummary(
 			time.Since(funcTimeStart),
 		)
 	}()
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSets[0].thresholds
 
 	switch {
 
@@ -1250,6 +1246,7 @@ func SnapshotsAgeOneLineCheckSummary(
 func SnapshotsCountOneLineCheckSummary(
 	stateLabel string,
 	snapshotSets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	evaluatedVMs []mo.VirtualMachine,
 	rps []mo.ResourcePool,
 ) string {
@@ -1262,11 +1259,6 @@ func SnapshotsCountOneLineCheckSummary(
 			time.Since(funcTimeStart),
 		)
 	}()
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSets[0].thresholds
 
 	switch {
 
@@ -1320,6 +1312,7 @@ func SnapshotsCountOneLineCheckSummary(
 func SnapshotsSizeOneLineCheckSummary(
 	stateLabel string,
 	snapshotSets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	evaluatedVMs []mo.VirtualMachine,
 	rps []mo.ResourcePool,
 ) string {
@@ -1332,11 +1325,6 @@ func SnapshotsSizeOneLineCheckSummary(
 			time.Since(funcTimeStart),
 		)
 	}()
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSets[0].thresholds
 
 	switch {
 
@@ -1713,6 +1701,7 @@ func writeSnapshotsReportFooter(
 func SnapshotsAgeReport(
 	c *vim25.Client,
 	snapshotSummarySets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	allVMs []mo.VirtualMachine,
 	evaluatedVMs []mo.VirtualMachine,
 	vmsWithIssues []mo.VirtualMachine,
@@ -1733,11 +1722,6 @@ func SnapshotsAgeReport(
 	}()
 
 	var report strings.Builder
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSummarySets[0].thresholds
 
 	writeSnapshotsListEntries(
 		&report,
@@ -1773,6 +1757,7 @@ func SnapshotsAgeReport(
 func SnapshotsSizeReport(
 	c *vim25.Client,
 	snapshotSummarySets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	allVMs []mo.VirtualMachine,
 	evaluatedVMs []mo.VirtualMachine,
 	vmsWithIssues []mo.VirtualMachine,
@@ -1793,11 +1778,6 @@ func SnapshotsSizeReport(
 	}()
 
 	var report strings.Builder
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSummarySets[0].thresholds
 
 	writeSnapshotsListEntries(
 		&report,
@@ -1833,6 +1813,7 @@ func SnapshotsSizeReport(
 func SnapshotsCountReport(
 	c *vim25.Client,
 	snapshotSummarySets SnapshotSummarySets,
+	snapshotThresholds SnapshotThresholds,
 	allVMs []mo.VirtualMachine,
 	evaluatedVMs []mo.VirtualMachine,
 	vmsWithIssues []mo.VirtualMachine,
@@ -1853,11 +1834,6 @@ func SnapshotsCountReport(
 	}()
 
 	var report strings.Builder
-
-	// Each SnapshotSummarySet records the thresholds used to create it, so we
-	// can pull the threshold values needed from the first item in the
-	// SnapshotSummarySets collection.
-	snapshotThresholds := snapshotSummarySets[0].thresholds
 
 	// TODO: See if it's feasible to merge with writeSnapshotsListEntries later
 	writeSnapshotsListEntries(


### PR DESCRIPTION
Revert the portion of e9d72a63cf803321b16508939b3bd2e5feeb06ef that removed explicit passing of snapshot thresholds to reporting funcs and relied upon the first snapshot entry to provide those details.

- fixes GH-473
- refs GH-451
- refs GH-453