### PR TITLE
Update lintinstall recipe to use `go install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ lintinstall:
 
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
-	@echo "Explicitly enabling Go modules mode per command"
-	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+	@echo "Installing latest staticcheck version ..."
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 	@echo Installing latest stable golangci-lint version per official installation script ...
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin


### PR DESCRIPTION
Replace deprecated `go get` syntax. Per official docs, the new syntax used builds the tool in module-aware mode. This accomplishes what we were using before but with a supported (and cleaner) syntax.

fixes GH-491
refs https://pkg.go.dev/cmd/go