### PR TITLE
Fix check_vmware_datastore warning state log msg

### DIFF
--- a/cmd/check_vmware_datastore/main.go
+++ b/cmd/check_vmware_datastore/main.go
@@ -308,7 +308,7 @@ func main() {
 
 	case dsUsage.IsWarningState():
 
-		log.Error().Msg("Datastore usage CRITICAL")
+		log.Error().Msg("Datastore usage WARNING")
 
 		nagiosExitState.LastError = vsphere.ErrDatastoreUsageThresholdCrossed
 


### PR DESCRIPTION
It incorrectly emits a CRITICAL state message.

fixes GH-515