### PR TITLE
Fix `var-declaration` `revive` linting error

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ import (
 // Updated via Makefile builds. Setting placeholder value here so that
 // something resembling a version string will be provided for non-Makefile
 // builds.
-var version string = "x.y.z"
+var version = "x.y.z"
 
 // ErrVersionRequested indicates that the user requested application version
 // information.


### PR DESCRIPTION
This was surfaced after replacing `golint` linter with `revive`.

refs GH-526
fixes GH-527