### PR TITLE
Swap `golint` linter for `revive`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,7 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - govet
 


### PR DESCRIPTION
fixes GH-526