### PR TITLE
Replace fully-qualified path for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1317,7 +1317,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_tools
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert  --log-level info
     }
 ```
 
@@ -1373,7 +1373,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vcpus
-    command_line    /usr/lib/nagios/plugins/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --trust-cert --log-level info
     }
 ```
 
@@ -1437,7 +1437,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_homogeneous
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 ```
 
@@ -1496,7 +1496,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_thresholds
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --trust-cert --log-level info
     }
 
 ```
@@ -1555,7 +1555,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_minreq
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --trust-cert --log-level info
     }
 
 ```
@@ -1618,7 +1618,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_defreq
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-minimum-version --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-minimum-version --trust-cert --log-level info
     }
 
 ```
@@ -1689,7 +1689,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name   check_vmware_hs2ds2vms
-    command_line   /usr/lib/nagios/plugins/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ca-name '$ARG4$' --ca-prefix-sep '$ARG5$' --trust-cert --log-level info
+    command_line   $USER1$/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ca-name '$ARG4$' --ca-prefix-sep '$ARG5$' --trust-cert --log-level info
     }
 ```
 
@@ -1733,7 +1733,7 @@ Of note:
 # CRITICAL threshold values.
 define command{
     command_name    check_vmware_datastore
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ds-usage-warning '$ARG4$' --ds-usage-critical '$ARG5$' --ds-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ds-usage-warning '$ARG4$' --ds-usage-critical '$ARG5$' --ds-name '$ARG6$' --trust-cert  --log-level info
     }
 ```
 
@@ -1783,7 +1783,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_age
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --trust-cert --log-level info
     }
 ```
 
@@ -1828,7 +1828,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_count
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --trust-cert --log-level info
     }
 ```
 
@@ -1873,7 +1873,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_size
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --trust-cert --log-level info
     }
 ```
 
@@ -1924,7 +1924,7 @@ specified Resource Pools are evaluated.
 # This variation of the command does not allow exclusions
 define command{
     command_name    check_vmware_resource_pools_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert  --log-level info
     }
 ```
 
@@ -1970,7 +1970,7 @@ Of note:
 # threshold values.
 define command{
     command_name    check_vmware_host_memory
-    command_line    /usr/lib/nagios/plugins/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
     }
 ```
 
@@ -2011,7 +2011,7 @@ Of note:
 # threshold values.
 define command{
     command_name    check_vmware_host_cpu
-    command_line    /usr/lib/nagios/plugins/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
     }
 ```
 
@@ -2051,7 +2051,7 @@ Of note:
 # are monitored equally.
 define command{
     command_name    check_vmware_vm_power_uptime
-    command_line    /usr/lib/nagios/plugins/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --trust-cert  --log-level info
     }
 ```
 
@@ -2106,7 +2106,7 @@ Of note:
 # is needed.
 define command{
     command_name    check_vmware_disk_consolidation
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, trigger potentially expensive reload operation
@@ -2121,7 +2121,7 @@ define command{
 # wish to schedule a job on the cluster to handle refreshing state data.
 define command{
     command_name    check_vmware_disk_consolidation_trigger_reload
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info --trigger-reload --timeout 110
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info --trigger-reload --timeout 110
     }
 
 ```
@@ -2161,7 +2161,7 @@ Of note:
 # environments where all VMs are monitored equally.
 define command{
     command_name    check_vmware_question
-    command_line    /usr/lib/nagios/plugins/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
     }
 ```
 
@@ -2219,14 +2219,14 @@ Of note:
 # any triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms within specified datacenters. Do not evaluate any
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --trust-cert --log-level info
     }
 ```
 

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-alarms.cfg
@@ -15,7 +15,7 @@
 # any triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 
 
@@ -30,14 +30,14 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms within specified datacenters. Evaluate any
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -50,7 +50,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_type
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$'  --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$'  --trust-cert --log-level info
     }
 
 # Look at triggered alarms for specified managed object types (e.g., Datastore
@@ -58,7 +58,7 @@ define command{
 # alarms which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_type_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects which do not match
@@ -67,7 +67,7 @@ define command{
 # alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_type
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects which do not match
@@ -76,7 +76,7 @@ define command{
 # which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_type_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-type '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -90,7 +90,7 @@ define command{
 # acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name matches the specified list of alarm name
@@ -99,7 +99,7 @@ define command{
 # not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name does not match the specified list of
@@ -108,7 +108,7 @@ define command{
 # acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose name does not match the specified list of
@@ -117,7 +117,7 @@ define command{
 # acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -131,7 +131,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_desc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description matches the specified list of
@@ -140,7 +140,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_desc_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description does not match the specified list
@@ -149,7 +149,7 @@ define command{
 # have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_desc
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose description does not match the specified list
@@ -158,7 +158,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_desc_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-desc '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -172,7 +172,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_status
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status matches the specified list of
@@ -181,7 +181,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_status_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status does not match the specified list of
@@ -190,7 +190,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_status
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose status does not match the specified list of
@@ -199,7 +199,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_status_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-status '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -213,7 +213,7 @@ define command{
 # have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name matches
@@ -222,7 +222,7 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name does not
@@ -231,7 +231,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_name
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose name does not
@@ -240,7 +240,7 @@ define command{
 # alarms which have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_name_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-name '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 
@@ -254,7 +254,7 @@ define command{
 # triggered alarms which have been previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms associated with managed objects whose resource pool
@@ -263,7 +263,7 @@ define command{
 # have been previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_include_entity_pools_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --include-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose resource pool name does not match the
@@ -272,7 +272,7 @@ define command{
 # previously acknowledged.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at triggered alarms whose resource pool name does not match the
@@ -281,5 +281,5 @@ define command{
 # previously acknowledged, but not yet resolved.
 define command{
     command_name    check_vmware_alarms_specific_dc_exclude_entity_pools_eval_acknowledged
-    command_line    /usr/lib/nagios/plugins/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_alarms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --dc-name '$ARG4$' --exclude-entity-rp '$ARG5$' --eval-acknowledged --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-datastores.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-datastores.cfg
@@ -10,5 +10,5 @@
 # CRITICAL threshold values.
 define command{
     command_name    check_vmware_datastore
-    command_line    /usr/lib/nagios/plugins/check_vmware_datastore --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ds-usage-warning '$ARG4$' --ds-usage-critical '$ARG5$' --ds-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_datastore --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ds-usage-warning '$ARG4$' --ds-usage-critical '$ARG5$' --ds-name '$ARG6$' --trust-cert  --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-disk-consolidation.cfg
@@ -11,7 +11,7 @@
 # triggering (potentially expensive) reload/refresh of state data.
 define command{
     command_name    check_vmware_disk_consolidation_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs. Use
@@ -20,7 +20,7 @@ define command{
 # data.
 define command{
     command_name    check_vmware_disk_consolidation_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs.  Use existing (potentially stale) state data for
@@ -32,7 +32,7 @@ define command{
 # is needed.
 define command{
     command_name    check_vmware_disk_consolidation
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs.  Use existing (potentially stale)
@@ -40,7 +40,7 @@ define command{
 # (potentially expensive) reload/refresh of state data.
 define command{
     command_name    check_vmware_disk_consolidation_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --ignore-vm '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --ignore-vm '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, trigger potentially expensive reload operation
@@ -55,5 +55,5 @@ define command{
 # wish to schedule a job on the cluster to handle refreshing state data.
 define command{
     command_name    check_vmware_disk_consolidation_trigger_reload
-    command_line    /usr/lib/nagios/plugins/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info --trigger-reload --timeout 110
+    command_line    $USER1$/check_vmware_disk_consolidation --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info --trigger-reload --timeout 110
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-host-cpu.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-host-cpu.cfg
@@ -10,5 +10,5 @@
 # threshold values.
 define command{
     command_name    check_vmware_host_cpu
-    command_line    /usr/lib/nagios/plugins/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_host_cpu --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cpu-usage-warning '$ARG4$' --cpu-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-host-datastore-vms-pairings.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-host-datastore-vms-pairings.cfg
@@ -11,7 +11,7 @@
 # Attribute prefix separator for hosts and datastores.
 define command{
     command_name   check_vmware_hs2ds2vms_include_pools
-    command_line   /usr/lib/nagios/plugins/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ca-name '$ARG5$' --ca-prefix-sep '$ARG6$' --trust-cert --log-level info
+    command_line   $USER1$/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ca-name '$ARG5$' --ca-prefix-sep '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
@@ -20,7 +20,7 @@ define command{
 # datastores.
 define command{
     command_name   check_vmware_hs2ds2vms_include_pools_exclude_vms
-    command_line   /usr/lib/nagios/plugins/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --ca-name '$ARG6$' --ca-prefix-sep '$ARG7$' --trust-cert --log-level info
+    command_line   $USER1$/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --ca-name '$ARG6$' --ca-prefix-sep '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -31,7 +31,7 @@ define command{
 # are monitored equally.
 define command{
     command_name   check_vmware_hs2ds2vms
-    command_line   /usr/lib/nagios/plugins/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ca-name '$ARG4$' --ca-prefix-sep '$ARG5$' --trust-cert --log-level info
+    command_line   $USER1$/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ca-name '$ARG4$' --ca-prefix-sep '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
@@ -39,5 +39,5 @@ define command{
 # same Custom Attribute prefix separator for hosts and datastores.
 define command{
     command_name   check_vmware_hs2ds2vms_exclude_vms
-    command_line   /usr/lib/nagios/plugins/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --ca-name '$ARG5$' --ca-prefix-sep '$ARG6$' --trust-cert --log-level info
+    command_line   $USER1$/check_vmware_hs2ds2vms --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --ca-name '$ARG5$' --ca-prefix-sep '$ARG6$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-host-memory.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-host-memory.cfg
@@ -10,5 +10,5 @@
 # threshold values.
 define command{
     command_name    check_vmware_host_memory
-    command_line    /usr/lib/nagios/plugins/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_host_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-usage-warning '$ARG4$' --memory-usage-critical '$ARG5$' --host-name '$ARG6$' --trust-cert  --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-interactive-question.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-interactive-question.cfg
@@ -9,24 +9,24 @@
 # Look at specific pools, exclude other pools
 define command{
     command_name    check_vmware_question_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs
 define command{
     command_name    check_vmware_question_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs. This variation of the command is most useful for
 # environments where all VMs are monitored equally.
 define command{
     command_name    check_vmware_question
-    command_line    /usr/lib/nagios/plugins/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs
 define command{
     command_name    check_vmware_question_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --ignore-vm '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_question --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --ignore-vm '$ARG4$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-resource-pools.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-resource-pools.cfg
@@ -8,11 +8,11 @@
 
 define command{
     command_name    check_vmware_resource_pools_exclude_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --exclude-rp '$ARG7$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --exclude-rp '$ARG7$' --trust-cert  --log-level info
     }
 
 # This variation of the command does not allow exclusions
 define command{
     command_name    check_vmware_resource_pools_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_rps_memory --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --memory-use-warning '$ARG4$' --memory-use-critical '$ARG5$' --memory-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert  --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-age.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-age.cfg
@@ -9,13 +9,13 @@
 # Look at specific pools, exclude other pools
 define command{
     command_name    check_vmware_snapshots_age_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_age_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -23,11 +23,11 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_age
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_age_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_age --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --age-warning '$ARG4$' --age-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-count.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-count.cfg
@@ -9,13 +9,13 @@
 # Look at specific pools, exclude other pools
 define command{
     command_name    check_vmware_snapshots_count_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_count_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -23,11 +23,11 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_count
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_count_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_count --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --count-warning '$ARG4$' --count-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-size.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-snapshots-size.cfg
@@ -9,13 +9,13 @@
 # Look at specific pools, exclude other pools
 define command{
     command_name    check_vmware_snapshots_size_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_size_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -23,11 +23,11 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_snapshots_size
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs
 define command{
     command_name    check_vmware_snapshots_size_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_snapshots_size --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --size-warning '$ARG4$' --size-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-tools.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-tools.cfg
@@ -9,14 +9,14 @@
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_tools_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert  --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_tools_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert  --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -24,12 +24,12 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_tools
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$'  --trust-cert  --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_tools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --trust-cert  --log-level info
+    command_line    $USER1$/check_vmware_tools --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --trust-cert  --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-vcpus.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-vcpus.cfg
@@ -9,14 +9,14 @@
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_vcpus_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --include-rp '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_vcpus_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --include-rp '$ARG7$' --ignore-vm '$ARG8$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --include-rp '$ARG7$' --ignore-vm '$ARG8$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -24,12 +24,12 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vcpus
-    command_line    /usr/lib/nagios/plugins/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_vcpus_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vcpus --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --vcpus-warning '$ARG4$' --vcpus-critical '$ARG5$' --vcpus-max-allowed '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-virtual-hardware.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-virtual-hardware.cfg
@@ -13,14 +13,14 @@
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_vhw_homogeneous_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_vhw_homogeneous_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --include-rp '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -28,14 +28,14 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_homogeneous
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_vhw_homogeneous_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --ignore-vm '$ARG4$' --trust-cert --log-level info
     }
 
 
@@ -48,14 +48,14 @@ define command{
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_vhw_thresholds_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_vhw_thresholds_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -63,14 +63,14 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_thresholds
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_vhw_thresholds_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --outdated-by-warning '$ARG4$' --outdated-by-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }
 
 
@@ -83,14 +83,14 @@ define command{
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_vhw_minreq_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --include-rp '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --include-rp '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_vhw_minreq_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --include-rp '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --include-rp '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -98,14 +98,14 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_minreq
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_vhw_minreq_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --minimum-version '$ARG4$' --ignore-vm '$ARG5$' --trust-cert --log-level info
     }
 
 
@@ -118,14 +118,14 @@ define command{
 # Look at specific pools only, do not evaluate any VMs that are powered off.
 define command{
     command_name    check_vmware_vhw_defreq_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --default-is-min-version --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --default-is-min-version --trust-cert --log-level info
     }
 
 # Look at specific pools only, exclude list of VMs, do not evaluate any VMs
 # that are powered off.
 define command{
     command_name    check_vmware_vhw_defreq_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --ignore-vm '$ARG6$' --default-is-min-version --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --include-rp '$ARG5$' --ignore-vm '$ARG6$' --default-is-min-version --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -133,12 +133,12 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vhw_defreq
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-min-version --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --default-is-min-version --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs, do not evaluate any VMs that are
 # powered off.
 define command{
     command_name    check_vmware_vhw_defreq_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --ignore-vm '$ARG5$' --default-is-min-version --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vhw --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --cluster-name '$ARG4$' --ignore-vm '$ARG5$' --default-is-min-version --trust-cert --log-level info
     }

--- a/contrib/nagios/etc/nagios-plugins/config/vmware-vm-power-uptime.cfg
+++ b/contrib/nagios/etc/nagios-plugins/config/vmware-vm-power-uptime.cfg
@@ -9,13 +9,13 @@
 # Look at specific pools, exclude other pools
 define command{
     command_name    check_vmware_vm_power_uptime_include_pools
-    command_line    /usr/lib/nagios/plugins/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --include-rp '$ARG6$' --trust-cert --log-level info
     }
 
 # Look at specific pools, exclude other pools, exclude list of VMs
 define command{
     command_name    check_vmware_vm_power_uptime_include_pools_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --include-rp '$ARG6$' --ignore-vm '$ARG7$' --trust-cert --log-level info
     }
 
 # Look at all pools, all VMs, do not evaluate any VMs that are powered off.
@@ -23,11 +23,11 @@ define command{
 # are monitored equally.
 define command{
     command_name    check_vmware_vm_power_uptime
-    command_line    /usr/lib/nagios/plugins/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --trust-cert --log-level info
     }
 
 # Look at all pools, exclude list of VMs
 define command{
     command_name    check_vmware_vm_power_uptime_exclude_vms
-    command_line    /usr/lib/nagios/plugins/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
+    command_line    $USER1$/check_vmware_vm_power_uptime --server '$HOSTNAME$' --domain '$ARG1$' --username '$ARG2$' --password '$ARG3$' --uptime-warning '$ARG4$' --uptime-critical '$ARG5$' --ignore-vm '$ARG6$' --trust-cert --log-level info
     }


### PR DESCRIPTION
Use the `$USER1$` macro already defined by the `resources.cfg`
file which allows for distro-agnostic path references.

This makes the contrib files more usable as-is for RHEL-based
distros or custom builds which store their plugins in
different locations than Debian-based distros.

fixes GH-517