### PR TITLE
Add missing deferring timing msgs to vsphere pkg

### DIFF
--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -169,6 +169,16 @@ func (tas TriggeredAlarms) NumExcludedFinal() int {
 // FilterByKey returns the matching TriggeredAlarm for the provided unique
 // identifier (key) for a TriggeredAlarm.
 func (tas TriggeredAlarms) FilterByKey(key string) (TriggeredAlarm, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute FilterByKey func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	for i := range tas {
 		if tas[i].Key == key {
 			return tas[i], nil
@@ -201,6 +211,15 @@ func (tas TriggeredAlarms) CountPerDatacenter() map[string]int {
 // order.
 func (tas TriggeredAlarms) Keys(evalAcknowledged bool, evalExcluded bool) []string {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Keys func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	keys := make([]string, 0, len(tas))
 	for i := range tas {
 		switch {
@@ -226,6 +245,15 @@ func (tas TriggeredAlarms) Keys(evalAcknowledged bool, evalExcluded bool) []stri
 // excluded. Keys are returned in ascending order.
 func (tas TriggeredAlarms) KeysExcluded() []string {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute KeysExcluded func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	keysExcl := make([]string, 0, len(tas))
 	for i := range tas {
 		if tas[i].Exclude {
@@ -244,6 +272,15 @@ func (tas TriggeredAlarms) KeysExcluded() []string {
 // Datacenters returns a list of Datacenter names associated with the
 // collection of TriggeredAlarms.
 func (tas TriggeredAlarms) Datacenters() []string {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Datacenters func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	dcsIdx := make(map[string]struct{})
 	dcs := make([]string, 0, len(tas))
@@ -267,6 +304,15 @@ func (tas TriggeredAlarms) Datacenters() []string {
 // ResourcePools returns a list of ResourcePool names associated with the
 // collection of TriggeredAlarms.
 func (tas TriggeredAlarms) ResourcePools() []string {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute ResourcePools func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	rpsIdx := make(map[string]struct{})
 	rps := make([]string, 0, len(tas))
@@ -297,6 +343,15 @@ func (tas TriggeredAlarms) ResourcePools() []string {
 // filtering the collection; processing of inclusion or exclusion lists should
 // be performed prior to calling this method.
 func (tas TriggeredAlarms) HasCriticalState(evalExcluded bool) bool {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute HasCriticalState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	if len(tas) == 0 {
 		return false
@@ -331,6 +386,15 @@ func (tas TriggeredAlarms) HasCriticalState(evalExcluded bool) bool {
 // prior to calling this method.
 func (tas TriggeredAlarms) NumCriticalState(evalExcluded bool) int {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NumCriticalState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	if len(tas) == 0 {
 		return 0
 	}
@@ -360,6 +424,15 @@ func (tas TriggeredAlarms) NumCriticalState(evalExcluded bool) int {
 // filtering the collection; processing of inclusion or exclusion lists should
 // be performed prior to calling this method.
 func (tas TriggeredAlarms) HasWarningState(evalExcluded bool) bool {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute HasWarningState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	if len(tas) == 0 {
 		return false
@@ -394,6 +467,15 @@ func (tas TriggeredAlarms) HasWarningState(evalExcluded bool) bool {
 // be performed prior to calling this method.
 func (tas TriggeredAlarms) NumWarningState(evalExcluded bool) int {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NumWarningState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	if len(tas) == 0 {
 		return 0
 	}
@@ -424,6 +506,15 @@ func (tas TriggeredAlarms) NumWarningState(evalExcluded bool) int {
 // filtering the collection; processing of inclusion or exclusion lists should
 // be performed prior to calling this method.
 func (tas TriggeredAlarms) HasUnknownState(evalExcluded bool) bool {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute HasUnknownState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	if len(tas) == 0 {
 		return false
@@ -457,6 +548,15 @@ func (tas TriggeredAlarms) HasUnknownState(evalExcluded bool) bool {
 // filtering the collection; processing of inclusion or exclusion lists should
 // be performed prior to calling this method.
 func (tas TriggeredAlarms) NumUnknownState(evalExcluded bool) int {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NumUnknownState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	if len(tas) == 0 {
 		return 0
@@ -508,6 +608,15 @@ func (tas TriggeredAlarms) IsOKState(evalExcluded bool) bool {
 // the collection; processing of inclusion or exclusion lists should be
 // performed prior to calling this method.
 func (tas TriggeredAlarms) NumOKState(evalExcluded bool) int {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NumOKState func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	var numOKState int
 
@@ -564,6 +673,15 @@ func (ta TriggeredAlarm) logIncluded(explicit bool) {
 // TriggeredAlarm has been marked for inclusion or exclusion, mostly for
 // debugging purposes.
 func logTriggeredAlarmMarked(triggeredAlarm TriggeredAlarm, keep bool, explicit bool) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute logTriggeredAlarmMarked func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	markType := "implicitly"
 	if explicit {

--- a/internal/vsphere/attributes.go
+++ b/internal/vsphere/attributes.go
@@ -10,6 +10,7 @@ package vsphere
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -48,6 +49,15 @@ var ErrAvailableFieldValueNotDefined = errors.New("no custom attributes defined 
 // not found.
 func CustomAttrKeyToValue(caKey int32, customValue []types.BaseCustomFieldValue) (string, error) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute CustomAttrKeyToValue func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	switch {
 
 	// this vSphere object has at least one custom attribute set
@@ -85,6 +95,15 @@ func CustomAttrKeyToValue(caKey int32, customValue []types.BaseCustomFieldValue)
 // match is not found.
 func CustomAttrNameToKey(caName string, availableField []types.CustomFieldDef) (int32, error) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute CustomAttrNameToKey func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	switch {
 	// this vSphere object has at least one custom attribute defined for its
 	// type (though not necessarily set)
@@ -117,6 +136,15 @@ func CustomAttrNameToKey(caName string, availableField []types.CustomFieldDef) (
 // returned if the value could not be retrieved indicating the cause of the
 // failure.
 func GetObjectCAVal(caName string, obj mo.ManagedEntity) (string, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute GetObjectCAVal func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	caKey, keyLookupErr := CustomAttrNameToKey(caName, obj.AvailableField)
 	if keyLookupErr != nil {

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -74,6 +74,15 @@ type DatastoreUsageSummary struct {
 // VirtualMachine details.
 func DatastoreVMsSummary(ds mo.Datastore, vms []mo.VirtualMachine) DatastoreVMs {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute DatastoreVMsSummary func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	datastoreVMs := make(DatastoreVMs, 0, len(vms))
 
 	for _, vm := range vms {
@@ -112,6 +121,15 @@ func NewDatastoreUsageSummary(
 	criticalThreshold int,
 	warningThreshold int,
 ) (DatastoreUsageSummary, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NewDatastoreUsageSummary func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	storageRemainingPercentage := float64(ds.Summary.FreeSpace) / float64(ds.Summary.Capacity) * 100
 	storageUsedPercentage := 100 - storageRemainingPercentage
@@ -314,6 +332,15 @@ func FilterDatastoresByID(dss []mo.Datastore, dsID string) (mo.Datastore, int, e
 // DatastoreIDsToNames returns a list of matching Datastore names for the
 // provided list of Managed Object References for Datastores.
 func DatastoreIDsToNames(dsRefs []types.ManagedObjectReference, dss []mo.Datastore) []string {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute DatastoreIDsToNames func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	dsNames := make([]string, 0, len(dsRefs))
 	dsIDs := make([]string, 0, len(dsRefs))

--- a/internal/vsphere/errors.go
+++ b/internal/vsphere/errors.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 )
 
 // ErrRuntimeTimeoutReached indicates that plugin runtime exceeded specified
@@ -25,6 +26,15 @@ var ErrRuntimeTimeoutReached = errors.New("plugin runtime exceeded specified tim
 // wrapped error. The original error is returned unmodified if no annotations
 // were deemed necessary.
 func AnnotateError(err error) error {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute AnnotateError func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	switch {
 

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -454,8 +454,20 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 // subset of all properties are returned for discovered ResourcePools.
 func getResourcePools(ctx context.Context, c *govmomi.Client, moRef types.ManagedObjectReference, propsSubset bool) ([]mo.ResourcePool, error) {
 
-	// Up to 2 can be returned, so set the initial size to match
+	funcTimeStart := time.Now()
+
+	// Up to 2 can be returned, so set the initial size to match. Declare this
+	// early so that we can grab a pointer to it in order to access the
+	// entries later
 	resourcePools := make([]mo.ResourcePool, 0, 2)
+
+	defer func(rp *[]mo.ResourcePool) {
+		logger.Printf(
+			"It took %v to execute getResourcePools func (and retrieve %d ResourcePools).\n",
+			time.Since(funcTimeStart),
+			len(*rp),
+		)
+	}(&resourcePools)
 
 	switch {
 	case moRef.Type == MgObjRefTypeResourcePool:

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -250,6 +250,15 @@ func NewHardwareVersionsIndex(vms []mo.VirtualMachine) (HardwareVersionsIndex, e
 // Versions returns a collection of all HardwareVersion entries from the index.
 func (hvi HardwareVersionsIndex) Versions() HardwareVersions {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Versions func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	newest := hvi.Newest().value
 	versions := make([]HardwareVersion, 0, len(hvi))
 	for hwv, count := range hvi {
@@ -274,6 +283,15 @@ func (hvi HardwareVersionsIndex) Versions() HardwareVersions {
 // Outdated returns a collection of all older HardwareVersion.
 func (hvi HardwareVersionsIndex) Outdated() HardwareVersions {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Outdated func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	newest := hvi.Newest().value
 	var outliers []HardwareVersion
 	for hwv, count := range hvi {
@@ -297,6 +315,15 @@ func (hvi HardwareVersionsIndex) Outdated() HardwareVersions {
 // formatted string in addition to the actual version number.
 func (hvi HardwareVersionsIndex) Newest() HardwareVersion {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Newest func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	keys := make([]string, 0, len(hvi))
 	for k := range hvi {
 		keys = append(keys, k)
@@ -319,6 +346,15 @@ func (hvi HardwareVersionsIndex) Newest() HardwareVersion {
 // is returned as a HardwareVersion type, providing both the original vmx-123
 // formatted string in addition to the actual version number.
 func (hvi HardwareVersionsIndex) Oldest() HardwareVersion {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Oldest func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	keys := make([]string, 0, len(hvi))
 	for k := range hvi {
@@ -390,6 +426,15 @@ func (hvs HardwareVersions) Sum() int {
 // string format.
 func (hvs HardwareVersions) VersionNames() []string {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute VersionNames func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	names := make([]string, 0, len(hvs))
 	for _, hwv := range hvs {
 		names = append(names, hwv.value)
@@ -406,6 +451,15 @@ func (hvs HardwareVersions) VersionNames() []string {
 // -1 is returned for each hardware version if there was an issue converting
 // the prefixed string value to a usable number.
 func (hvs HardwareVersions) VersionNumbers() []int {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute VersionNumbers func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	versionNums := make([]int, 0, len(hvs))
 	for _, hwv := range hvs {
@@ -438,6 +492,15 @@ func (hvs HardwareVersions) MeetsMinVersion(minVer int) bool {
 // to just those with older hardware versions. The collection is returned
 // along with the number of VirtualMachines that were excluded.
 func FilterVMsWithOldHardware(vms []mo.VirtualMachine, hwIndex HardwareVersionsIndex) ([]mo.VirtualMachine, int) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute FilterVMsWithOldHardware func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	var vmsWithOldHardware []mo.VirtualMachine
 	for _, vm := range vms {

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -119,7 +119,17 @@ type VMToMismatchedDatastoreNames map[string]VMHostDatastoresPairing
 // VirtualMachines (if any) and an error (if applicable).
 func GetVMDatastorePairingIssues(vms []mo.VirtualMachine, h2dIdx HostToDatastoreIndex, dss []mo.Datastore, ignoredDatastoreNames []string) (VMToMismatchedDatastoreNames, error) {
 
+	funcTimeStart := time.Now()
+
 	vmDatastoresPairingIssues := make(VMToMismatchedDatastoreNames)
+
+	defer func(issues *VMToMismatchedDatastoreNames) {
+		logger.Printf(
+			"It took %v to execute GetVMDatastorePairingIssues func (and retrieve %d VMToMismatchedDatastoreNames).\n",
+			time.Since(funcTimeStart),
+			len(*issues),
+		)
+	}(&vmDatastoresPairingIssues)
 
 	for _, vm := range vms {
 
@@ -251,7 +261,17 @@ func GetVMDatastorePairingIssues(vms []mo.VirtualMachine, h2dIdx HostToDatastore
 // with an error (if applicable).
 func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ignoreMissingCA bool) ([]HostWithCA, error) {
 
+	funcTimeStart := time.Now()
+
 	hostsWithCAs := make([]HostWithCA, 0, len(allHosts))
+
+	defer func(hosts *[]HostWithCA) {
+		logger.Printf(
+			"It took %v to execute GetHostsWithCA func (and retrieve %d HostWithCAs).\n",
+			time.Since(funcTimeStart),
+			len(*hosts),
+		)
+	}(&hostsWithCAs)
 
 	for _, host := range allHosts {
 		caVal, caValErr := GetObjectCAVal(hostCustomAttributeName, host.ManagedEntity)
@@ -314,10 +334,22 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 // applicable).
 func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, dsCustomAttributeName string, ignoreMissingCA bool) ([]DatastoreWithCA, error) {
 
+	funcTimeStart := time.Now()
+
 	dsNames := make([]string, 0, len(allDS))
 	for _, ds := range allDS {
 		dsNames = append(dsNames, ds.Name)
 	}
+
+	datastoresWithCA := make([]DatastoreWithCA, 0, len(allDS))
+
+	defer func(dss *[]DatastoreWithCA) {
+		logger.Printf(
+			"It took %v to execute GetDatastoresWithCA func (and retrieve %d DatastoreWithCAs).\n",
+			time.Since(funcTimeStart),
+			len(*dss),
+		)
+	}(&datastoresWithCA)
 
 	// validate the list of ignored datastores
 	if len(ignoredDatastoreNames) > 0 {
@@ -348,8 +380,6 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 			}
 		}
 	}
-
-	datastoresWithCA := make([]DatastoreWithCA, 0, len(allDS))
 
 	for _, ds := range allDS {
 
@@ -434,6 +464,15 @@ func NewHostToDatastoreIndex(
 	hostCASep string,
 	datastoreCASep string,
 ) (HostToDatastoreIndex, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NewHostToDatastoreIndex func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	h2dIdx := make(HostToDatastoreIndex)
 
@@ -580,7 +619,18 @@ func NewHostToDatastoreIndex(
 // DatastoreNames returns a list of all Datastore names in the index.
 func (hdi HostToDatastoreIndex) DatastoreNames() []string {
 
+	funcTimeStart := time.Now()
+
 	var dsNames []string
+
+	defer func(dss *[]string) {
+		logger.Printf(
+			"It took %v to execute DatastoreNames func (and retrieve %d Datastore names).\n",
+			time.Since(funcTimeStart),
+			len(*dss),
+		)
+	}(&dsNames)
+
 	for hostID := range hdi {
 		for _, ds := range hdi[hostID].Datastores {
 			dsNames = append(dsNames, ds.Name)
@@ -597,6 +647,15 @@ func (hdi HostToDatastoreIndex) DatastoreNames() []string {
 
 // DatastoreIDToNameIndex returns an index of all Datastore IDs to names in the index.
 func (hdi HostToDatastoreIndex) DatastoreIDToNameIndex() DatastoreIDToNameIndex {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute DatastoreIDToNameIndex func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	dsIdx := make(DatastoreIDToNameIndex)
 	for hostID := range hdi {
@@ -629,6 +688,15 @@ func (hdi HostToDatastoreIndex) IsDatastoreIDInIndex(dsID string) bool {
 // is returned if the name could not be retrieved from the index.
 func (hdi HostToDatastoreIndex) DatastoreIDToName(dsID string) (string, error) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute DatastoreIDToName func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	for hostID := range hdi {
 		for _, ds := range hdi[hostID].Datastores {
 			if ds.Self.Value == dsID {
@@ -653,6 +721,15 @@ func (hdi HostToDatastoreIndex) ValidateVirtualMachinePairings(
 	vmDatastoreRefs []types.ManagedObjectReference,
 	dsNamesToIgnore []string,
 ) ([]string, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute ValidateVirtualMachinePairings func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	// fmt.Println("All datastores length:", len(allDatastores))
 	// fmt.Println("vmDatastoreRefs length:", len(vmDatastoreRefs))

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -79,6 +79,15 @@ type HostSystemCPUSummary struct {
 // issue for service account) an error is returned indicating this.
 func NewHostSystemMemoryUsageSummary(hs mo.HostSystem, criticalThreshold int, warningThreshold int) (HostSystemMemorySummary, error) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NewHostSystemMemoryUsageSummary func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	if hs.Summary.Hardware == nil {
 		return HostSystemMemorySummary{}, fmt.Errorf(
 			"error creating HostSystemMemorySummary: %w",
@@ -118,6 +127,15 @@ func NewHostSystemMemoryUsageSummary(hs mo.HostSystem, criticalThreshold int, wa
 // thresholds. If required information is not accessible (e.g., permissions
 // issue for service account) an error is returned indicating this.
 func NewHostSystemCPUUsageSummary(hs mo.HostSystem, criticalThreshold int, warningThreshold int) (HostSystemCPUSummary, error) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute NewHostSystemCPUUsageSummary func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	if hs.Summary.Hardware == nil {
 		return HostSystemCPUSummary{}, fmt.Errorf(
@@ -328,7 +346,7 @@ func GetHostSystemsTotalMemory(ctx context.Context, c *vim25.Client, excludeOffl
 
 	defer func() {
 		logger.Printf(
-			"It took %v to execute GetHostSystemTotalMemory func.\n",
+			"It took %v to execute GetHostSystemsTotalMemory func.\n",
 			time.Since(funcTimeStart),
 		)
 	}()

--- a/internal/vsphere/login.go
+++ b/internal/vsphere/login.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/vmware/govmomi"
 )
@@ -31,6 +32,15 @@ func Login(
 ) (*govmomi.Client, error) {
 
 	// TODO: Do we really need to support user domains?
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute Login func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	vCenterURL := fmt.Sprintf("https://%s:%d/sdk", server, port)
 

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -662,6 +662,15 @@ func (sss SnapshotSummarySets) AgeCriticalSnapshots() (int, int) {
 // total (age) WARNING snapshots across all VirtualMachines.
 func (sss SnapshotSummarySets) AgeWarningSnapshots() (int, int) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute AgeWarningSnapshots func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	// Skip attempts to process empty collection.
 	if len(sss) == 0 {
 		return 0, 0
@@ -713,6 +722,15 @@ func (sss SnapshotSummarySets) AgeWarningSnapshots() (int, int) {
 // CRITICAL snapshots across all VirtualMachines.
 func (sss SnapshotSummarySets) SizeCriticalSnapshots() (int, int) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute SizeCriticalSnapshots func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	// Skip attempts to process empty collection.
 	if len(sss) == 0 {
 		return 0, 0
@@ -733,6 +751,15 @@ func (sss SnapshotSummarySets) SizeCriticalSnapshots() (int, int) {
 // snapshots and the total (size) WARNING snapshots across all
 // VirtualMachines.
 func (sss SnapshotSummarySets) SizeWarningSnapshots() (int, int) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute SizeWarningSnapshots func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	// Skip attempts to process empty collection.
 	if len(sss) == 0 {
@@ -855,6 +882,15 @@ func removeFileKey(l *[]int32, key int32) {
 // ListVMSnapshots generates a quick listing of all snapshots for a given VM
 // and emits the results to the provided io.Writer.
 func ListVMSnapshots(vm mo.VirtualMachine, w io.Writer) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute ListVMSnapshots func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	now := time.Now()
 
@@ -1386,6 +1422,15 @@ func writeSnapshotsListEntries(
 	snapshotSummarySets SnapshotSummarySets,
 ) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute writeSnapshotsListEntries func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	listEntryTemplate := "* %q [Age: %v, Size (item: %v, sum: %v), Name: %q, Datastore: %q]\n"
 
 	printSnapshotHeader := func(forWhat string, exceeding bool) {
@@ -1608,6 +1653,15 @@ func writeSnapshotsReportFooter(
 	excludeRPs []string,
 	rps []mo.ResourcePool,
 ) {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute writeSnapshotsReportFooter func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	rpNames := make([]string, len(rps))
 	for i := range rps {

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -49,7 +49,18 @@ type VirtualMachinePowerCycleUptimeStatus struct {
 // specified power cycle uptime thresholds. VirtualMachines which have yet to
 // exceed specified thresholds are not listed.
 func (vpcs VirtualMachinePowerCycleUptimeStatus) VMNames() string {
+
+	funcTimeStart := time.Now()
+
 	vmNames := make([]string, 0, len(vpcs.VMsCritical)+len(vpcs.VMsWarning))
+
+	defer func(names *[]string) {
+		logger.Printf(
+			"It took %v to execute VMNames func (and retrieve %d Datastores).\n",
+			time.Since(funcTimeStart),
+			len(*names),
+		)
+	}(&vmNames)
 
 	for _, vm := range vpcs.VMsWarning {
 		vmNames = append(vmNames, vm.Name)
@@ -68,6 +79,15 @@ func (vpcs VirtualMachinePowerCycleUptimeStatus) VMNames() string {
 // TopTenOK is a helper method that returns at most ten VMs with the highest
 // power cycle uptime values that have yet to exceed specified thresholds.
 func (vpcs VirtualMachinePowerCycleUptimeStatus) TopTenOK() []mo.VirtualMachine {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute TopTenOK func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	// sort before we sample the VMs so that we only get the ones with highest
 	// power cycle uptime
@@ -94,6 +114,15 @@ func (vpcs VirtualMachinePowerCycleUptimeStatus) TopTenOK() []mo.VirtualMachine 
 // power cycle uptime values that have yet to exceed specified thresholds.
 // Only powered on VMs are considered.
 func (vpcs VirtualMachinePowerCycleUptimeStatus) BottomTenOK() []mo.VirtualMachine {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute BottomTenOK func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	poweredOnVMs, _ := FilterVMsByPowerState(vpcs.VMsOK, false)
 
@@ -387,6 +416,15 @@ func FilterVMsByID(vms []mo.VirtualMachine, vmID string) (mo.VirtualMachine, int
 // any others silently skipped.
 func ExcludeVMsByName(allVMs []mo.VirtualMachine, ignoreList []string) ([]mo.VirtualMachine, int) {
 
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute ExcludeVMsByName func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
+
 	if len(allVMs) == 0 || len(ignoreList) == 0 {
 		return allVMs, 0
 	}
@@ -598,6 +636,15 @@ func dedupeVMs(vmsList []mo.VirtualMachine) []mo.VirtualMachine {
 // VMNames receives a list of VirtualMachine values and returns a new list of
 // VirtualMachine Name values.
 func VMNames(vmsList []mo.VirtualMachine) []string {
+
+	funcTimeStart := time.Now()
+
+	defer func() {
+		logger.Printf(
+			"It took %v to execute VMNames func.\n",
+			time.Since(funcTimeStart),
+		)
+	}()
 
 	vmNames := make([]string, 0, len(vmsList))
 	for i := range vmsList {


### PR DESCRIPTION
Add additional deferred timing log messages to functions and methods in the `internal/vsphere` package. Even with these changes coverage is not 100%. 

Further review is necessary to add additional deferred log messages and potentially to remove log messages recently added (for minor functions and methods).

fixes GH-514