### PR TITLE
Update go.mod to reflect current dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/check-vmware
 
-go 1.15
+go 1.14
 
 require (
 	github.com/atc0005/go-nagios v0.8.1


### PR DESCRIPTION
Drop from 1.15 to 1.14 to reflect what appears to be the actual minimum Go version required.

fixes GH-534