### PR TITLE
Simplify handling of Datastore Perf Latency flags

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,46 +144,31 @@ type DSPerformanceSummaryThresholds struct {
 	VMLatencyCritical float64
 }
 
-// MultiValueDSPerfLatencyMetricFlag is a custom type that satisfies the
+// dsPerfLatencyMetricFlag is a custom type that satisfies the
 // flag.Value interface. This type is used to accept Datastore Performance
 // Summary latency metric values. This flag type is incompatible with the flag
 // type used to specify percentile sets.
-//
-// NOTE: Abandoning this for now. The flag package will call the Set() method
-// for this type regardless of whether the user calls the
-//
-type MultiValueDSPerfLatencyMetricFlag struct {
-
-	// value is the user-specified value
-	value float64
-
-	// isSet identifies whether a value was provided by the user
-	isSet bool
-}
+type dsPerfLatencyMetricFlag float64
 
 // String satisfies the flag.Value interface method set requirements.
-func (mvdspl *MultiValueDSPerfLatencyMetricFlag) String() string {
+func (dspl *dsPerfLatencyMetricFlag) String() string {
 
 	// The String() method is called by the flag.isZeroValue function in order
 	// to determine whether the output string represents the zero value for a
 	// flag. This occurs even if the flag is not specified by the user.
 
-	if mvdspl == nil {
+	if dspl == nil {
 		return ""
 	}
 
-	return fmt.Sprintf(
-		"value: %v, isSet: %v",
-		mvdspl.value,
-		mvdspl.isSet,
-	)
+	return strconv.FormatFloat(float64(*dspl), 'E', -1, 64)
 
 }
 
 // Set satisfies (barely) the flag.Value interface method set requirements.
-func (mvdspl *MultiValueDSPerfLatencyMetricFlag) Set(value string) error {
+func (dspl *dsPerfLatencyMetricFlag) Set(value string) error {
 
-	// fmt.Println("MultiValueDSPerfLatencyMetricFlag Set() called")
+	// fmt.Println("dsPerfLatencyMetricFlag Set() called")
 
 	var strConvErr error
 
@@ -201,8 +186,8 @@ func (mvdspl *MultiValueDSPerfLatencyMetricFlag) Set(value string) error {
 		)
 	}
 
-	mvdspl.value = parsedVal
-	mvdspl.isSet = true
+	val := dsPerfLatencyMetricFlag(parsedVal)
+	dspl = &val
 
 	return nil
 
@@ -680,29 +665,29 @@ type Config struct {
 
 	// datastoreReadLatencyWarning specifies the read latency of a datastore's
 	// storage (in ms) when a WARNING threshold is reached.
-	datastoreReadLatencyWarning MultiValueDSPerfLatencyMetricFlag
+	datastoreReadLatencyWarning *dsPerfLatencyMetricFlag
 
 	// datastoreReadLatencyWarning specifies the read latency of a datastore's
 	// storage (in ms) when a CRITICAL threshold is reached.
-	datastoreReadLatencyCritical MultiValueDSPerfLatencyMetricFlag
+	datastoreReadLatencyCritical *dsPerfLatencyMetricFlag
 
 	// datastoreWriteLatencyWarning specifies the write latency of a
 	// datastore's storage (in ms) when a WARNING threshold is reached.
-	datastoreWriteLatencyWarning MultiValueDSPerfLatencyMetricFlag
+	datastoreWriteLatencyWarning *dsPerfLatencyMetricFlag
 
 	// datastoreWriteLatencyCritical specifies the write latency of a
 	// datastore's storage (in ms) when a CRITICAL threshold is reached.
-	datastoreWriteLatencyCritical MultiValueDSPerfLatencyMetricFlag
+	datastoreWriteLatencyCritical *dsPerfLatencyMetricFlag
 
 	// datastoreVMLatencyWarning specifies the latency of a datastore's
 	// storage (in ms) as observed by VMs using the datastore when a WARNING
 	// threshold is reached.
-	datastoreVMLatencyWarning MultiValueDSPerfLatencyMetricFlag
+	datastoreVMLatencyWarning *dsPerfLatencyMetricFlag
 
 	// datastoreVMLatencyWarning specifies the latency of a datastore's
 	// storage (in ms) as observed by VMs using the datastore when a CRITICAL
 	// threshold is reached.
-	datastoreVMLatencyCritical MultiValueDSPerfLatencyMetricFlag
+	datastoreVMLatencyCritical *dsPerfLatencyMetricFlag
 
 	// datastorePerformancePercentileSet specifies the set of
 	// DatastorePerformanceSummary latency thresholds associated with a

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -171,23 +171,23 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.BoolVar(&c.HideHistoricalDatastorePerfMetricSets, "ds-hide-historical-metric-sets", defaultHideHistoricalDatastorePerfMetricSets, hideHistoricalDatastorePerfMetricSetsFlagHelp)
 		flag.BoolVar(&c.HideHistoricalDatastorePerfMetricSets, "dshhms", defaultHideHistoricalDatastorePerfMetricSets, hideHistoricalDatastorePerfMetricSetsFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreReadLatencyWarning, "ds-read-latency-warning", datastoreReadLatencyWarningFlagHelp)
-		flag.Var(&c.datastoreReadLatencyWarning, "dsrlw", datastoreReadLatencyWarningFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreReadLatencyWarning, "ds-read-latency-warning", datastoreReadLatencyWarningFlagHelp)
+		flag.Var(c.datastoreReadLatencyWarning, "dsrlw", datastoreReadLatencyWarningFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreReadLatencyCritical, "ds-read-latency-critical", datastoreReadLatencyCriticalFlagHelp)
-		flag.Var(&c.datastoreReadLatencyCritical, "dsrlc", datastoreReadLatencyCriticalFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreReadLatencyCritical, "ds-read-latency-critical", datastoreReadLatencyCriticalFlagHelp)
+		flag.Var(c.datastoreReadLatencyCritical, "dsrlc", datastoreReadLatencyCriticalFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreWriteLatencyWarning, "ds-write-latency-warning", datastoreWriteLatencyWarningFlagHelp)
-		flag.Var(&c.datastoreWriteLatencyWarning, "dswlw", datastoreWriteLatencyWarningFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreWriteLatencyWarning, "ds-write-latency-warning", datastoreWriteLatencyWarningFlagHelp)
+		flag.Var(c.datastoreWriteLatencyWarning, "dswlw", datastoreWriteLatencyWarningFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreWriteLatencyCritical, "ds-write-latency-critical", datastoreWriteLatencyCriticalFlagHelp)
-		flag.Var(&c.datastoreWriteLatencyCritical, "dswlc", datastoreWriteLatencyCriticalFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreWriteLatencyCritical, "ds-write-latency-critical", datastoreWriteLatencyCriticalFlagHelp)
+		flag.Var(c.datastoreWriteLatencyCritical, "dswlc", datastoreWriteLatencyCriticalFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreVMLatencyWarning, "ds-vm-latency-warning", datastoreVMLatencyWarningFlagHelp)
-		flag.Var(&c.datastoreVMLatencyWarning, "dsvmlw", datastoreVMLatencyWarningFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreVMLatencyWarning, "ds-vm-latency-warning", datastoreVMLatencyWarningFlagHelp)
+		flag.Var(c.datastoreVMLatencyWarning, "dsvmlw", datastoreVMLatencyWarningFlagHelp+" (shorthand)")
 
-		flag.Var(&c.datastoreVMLatencyCritical, "ds-vm-latency-critical", datastoreVMLatencyCriticalFlagHelp)
-		flag.Var(&c.datastoreVMLatencyCritical, "dsvmlc", datastoreVMLatencyCriticalFlagHelp+" (shorthand)")
+		flag.Var(c.datastoreVMLatencyCritical, "ds-vm-latency-critical", datastoreVMLatencyCriticalFlagHelp)
+		flag.Var(c.datastoreVMLatencyCritical, "dsvmlc", datastoreVMLatencyCriticalFlagHelp+" (shorthand)")
 
 		flag.Var(&c.datastorePerformancePercentileSet, "ds-latency-percentile-set", datastoreLatencyPercintileSetFlagHelp)
 		flag.Var(&c.datastorePerformancePercentileSet, "dslps", datastoreLatencyPercintileSetFlagHelp+" (shorthand)")

--- a/internal/config/getters.go
+++ b/internal/config/getters.go
@@ -159,33 +159,33 @@ func (c Config) UserAgent() string {
 func (c Config) DatastorePerfThresholds() DSPerformanceSummaryThresholds {
 
 	readLatencyWarning := defaultDatastoreReadLatencyWarning
-	if c.datastoreReadLatencyWarning.isSet {
-		readLatencyWarning = c.datastoreReadLatencyWarning.value
+	if c.datastoreReadLatencyWarning != nil {
+		readLatencyWarning = float64(*c.datastoreReadLatencyWarning)
 	}
 
 	readLatencyCritical := defaultDatastoreReadLatencyCritical
-	if c.datastoreReadLatencyCritical.isSet {
-		readLatencyCritical = c.datastoreReadLatencyCritical.value
+	if c.datastoreReadLatencyCritical != nil {
+		readLatencyCritical = float64(*c.datastoreReadLatencyCritical)
 	}
 
 	writeLatencyWarning := defaultDatastoreWriteLatencyWarning
-	if c.datastoreWriteLatencyWarning.isSet {
-		writeLatencyWarning = c.datastoreWriteLatencyWarning.value
+	if c.datastoreWriteLatencyWarning != nil {
+		writeLatencyWarning = float64(*c.datastoreWriteLatencyWarning)
 	}
 
 	writeLatencyCritical := defaultDatastoreWriteLatencyCritical
-	if c.datastoreWriteLatencyCritical.isSet {
-		writeLatencyCritical = c.datastoreWriteLatencyCritical.value
+	if c.datastoreWriteLatencyCritical != nil {
+		writeLatencyCritical = float64(*c.datastoreWriteLatencyCritical)
 	}
 
 	vmLatencyWarning := defaultDatastoreVMLatencyWarning
-	if c.datastoreVMLatencyWarning.isSet {
-		vmLatencyWarning = c.datastoreVMLatencyWarning.value
+	if c.datastoreVMLatencyWarning != nil {
+		vmLatencyWarning = float64(*c.datastoreVMLatencyWarning)
 	}
 
 	vmLatencyCritical := defaultDatastoreVMLatencyCritical
-	if c.datastoreVMLatencyCritical.isSet {
-		vmLatencyCritical = c.datastoreVMLatencyCritical.value
+	if c.datastoreVMLatencyCritical != nil {
+		vmLatencyCritical = float64(*c.datastoreVMLatencyCritical)
 	}
 
 	return DSPerformanceSummaryThresholds{

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -243,7 +243,7 @@ func (c Config) validate(pluginType PluginType) error {
 		// latency flags are not permitted.
 		case len(c.datastorePerformancePercentileSet) > 0:
 
-			latencyThresholdFlags := []MultiValueDSPerfLatencyMetricFlag{
+			latencyThresholdFlags := []*dsPerfLatencyMetricFlag{
 				c.datastoreReadLatencyWarning,
 				c.datastoreReadLatencyCritical,
 				c.datastoreWriteLatencyWarning,
@@ -253,7 +253,7 @@ func (c Config) validate(pluginType PluginType) error {
 			}
 
 			for i := range latencyThresholdFlags {
-				if latencyThresholdFlags[i].isSet {
+				if latencyThresholdFlags[i] != nil {
 					return fmt.Errorf(
 						"invalid combination of flags; percentile set flag is incompatible with individual latency threshold flags",
 					)


### PR DESCRIPTION
- Rename `MultiValueDSPerfLatencyMetricFlag` type to
  `dsPerfLatencyMetricFlag` to reflect that it does not represent
  a flag which accepts multiple values (e.g., CSV)
  - also, set type as unexported since it will not be accessed
    directly, but will instead be used as part of building a
    more complex type that is used instead

- Update custom `dsPerfLatencyMetricFlag` type to use `float64`
  as the base type, methods used to implement `flag.Value`
  interface to reflect the base type change

- Update `Config` fields and validation logic to reflect change
  of fields from structs to pointer type

- Prune old/invalid doc comments regarding not using the type
  - this was evidently left behind from earlier scatch work
    and not cleaned up when preparing the initial PR

fixes GH-551