### PR TITLE
Treat vApp as Resource Pool when collecting alarms

### DIFF
--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -793,6 +793,7 @@ func GetTriggeredAlarms(ctx context.Context, c *govmomi.Client, datacenters []mo
 			resourcePoolNames := make([]string, 0, 2)
 			switch {
 			case entity.Self.Type == MgObjRefTypeResourcePool ||
+				entity.Self.Type == MgObjRefTypeVirtualApp ||
 				entity.Self.Type == MgObjRefTypeVirtualMachine:
 
 				rps, err := getResourcePools(ctx, c, entity.Self, propsSubset)


### PR DESCRIPTION
Include vApps as valid potential members of resource pools. This is needed in order to properly include/exclude alarms based on resource pool membership.

fixes GH-558