### PR TITLE
Rework `*_remaining` and `*_used` metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ The following types of changes will be recorded in this file:
     - `datastore_storage_used` renamed to `datastore_space_used`
     - `datastore_storage_remaining` to `datastore_space_remaining`
 
+- (GH-480) `*_used` and `*_remaining` metrics changed to no longer emit `Max`
+  and `Min` thresholds (current values only)
+  - `check_vmware_datastore_space`
+  - `check_vmware_host_cpu`
+  - `check_vmware_host_memory`
+  - `check_vmware_rps_memory`
+  - `check_vmware_vcpus`
+
 ### Added
 
 - placeholder

--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -261,15 +261,11 @@ func main() {
 			Label:             "datastore_space_used",
 			Value:             fmt.Sprintf("%d", dsSpaceUsage.StorageUsed),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", dsSpaceUsage.StorageTotal),
-			Min:               "0",
 		},
 		{
 			Label:             "datastore_space_remaining",
 			Value:             fmt.Sprintf("%d", dsSpaceUsage.StorageRemaining),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", dsSpaceUsage.StorageTotal),
-			Min:               "0",
 		},
 		{
 			Label: "vms",

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -270,15 +270,11 @@ func main() {
 			Label:             "cpu_used",
 			Value:             fmt.Sprintf("%.2f", hsUsage.CPUUsed),
 			UnitOfMeasurement: "Hz",
-			Max:               fmt.Sprintf("%.2f", hsUsage.CPUTotal),
-			Min:               "0",
 		},
 		{
 			Label:             "cpu_remaining",
 			Value:             fmt.Sprintf("%.2f", hsUsage.CPURemaining),
 			UnitOfMeasurement: "Hz",
-			Max:               fmt.Sprintf("%.2f", hsUsage.CPUTotal),
-			Min:               "0",
 		},
 		{
 			Label: "vms",

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -271,15 +271,11 @@ func main() {
 			Label:             "memory_used",
 			Value:             fmt.Sprintf("%d", hsUsage.MemoryUsed),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", hsUsage.MemoryTotal),
-			Min:               "0",
 		},
 		{
 			Label:             "memory_remaining",
 			Value:             fmt.Sprintf("%d", hsUsage.MemoryRemaining),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", hsUsage.MemoryTotal),
-			Min:               "0",
 		},
 		{
 			Label: "vms",

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -335,15 +335,11 @@ func main() {
 			Label:             "memory_used",
 			Value:             fmt.Sprintf("%d", aggregateMemoryUsageInBytes),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", cfg.ResourcePoolsMemoryMaxAllowed),
-			Min:               fmt.Sprintf("%d", 0),
 		},
 		{
 			Label:             "memory_remaining",
 			Value:             fmt.Sprintf("%d", memoryRemainingInBytes),
 			UnitOfMeasurement: "B",
-			Max:               fmt.Sprintf("%d", cfg.ResourcePoolsMemoryMaxAllowed),
-			Min:               fmt.Sprintf("%d", 0),
 		},
 		{
 			Label: "resource_pools_excluded",

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -306,14 +306,10 @@ func main() {
 		{
 			Label: "vcpus_used",
 			Value: fmt.Sprintf("%d", vCPUsAllocated),
-			Max:   fmt.Sprintf("%d", cfg.VCPUsMaxAllowed),
-			Min:   fmt.Sprintf("%d", 0),
 		},
 		{
 			Label: "vcpus_remaining",
 			Value: fmt.Sprintf("%d", vCPUsRemaining),
-			Max:   fmt.Sprintf("%d", cfg.VCPUsMaxAllowed),
-			Min:   fmt.Sprintf("%d", 0),
 		},
 		{
 			Label: "resource_pools_excluded",


### PR DESCRIPTION
Updated plugins:

- check_vmware_datastore_space
- check_vmware_host_cpu
- check_vmware_host_memory
- check_vmware_rps_memory
- check_vmware_vcpus

Drop `Max` and `Min` qualifiers so that these metrics are based
solely on current values. The intent is to provide historical
details soley for planning purposes (without attaching a
specific severity to the values); the `*_usage` metrics remain
the intended metric for determining severity.

Update CHANGELOG to note this is a breaking change.

fixes GH-480