### PR TITLE
Update GHAW timeout settings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    # Default: 360 minutes
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -78,7 +78,7 @@ jobs:
     name: Build codebase using Makefile quick recipe
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 40
+    timeout-minutes: 10
     container:
       image: "index.docker.io/golang:latest"
 


### PR DESCRIPTION
- update `CodeQL` workflow to override 360 minutes default
  timeout setting with explicit 10 minute timeout
- update `Lint and Build using Makefile` workflow to reduce
  explicit 40 minute timeout for the
  `Build codebase using Makefile quick recipe` job to 10 minutes

fixes GH-581