### PR TITLE
Update priority of VM backup error conditions

### DIFF
--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -351,7 +351,10 @@ func main() {
 			switch {
 
 			// Something prevented a regularly scheduled backup from
-			// running/completing
+			// running/completing.
+			//
+			// We consider this error to be of a higher priority, so we check
+			// for it first before we look for missing backups.
 			case vmsWithBackup.HasOldBackup():
 				return vsphere.ErrVirtualMachineBackupDateOld
 

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -2059,16 +2059,6 @@ func VMBackupViaCAOneLineCheckSummary(
 	}
 
 	switch {
-	case numMissingBackups > 0:
-		return fmt.Sprintf(
-			"%s: %d VMs missing backups detected (%d present & %d current, evaluated %d VMs & %d Resource Pools)",
-			stateLabel,
-			numMissingBackups,
-			numWithBackups,
-			numCurrentBackups,
-			len(evaluatedVMs),
-			len(rps),
-		)
 	case numWithOldBackups > 0:
 		numCurrentBackups := numWithBackups - numWithOldBackups
 		if numCurrentBackups < 0 {
@@ -2078,6 +2068,17 @@ func VMBackupViaCAOneLineCheckSummary(
 			"%s: %d VMs with old backups detected (%d current, evaluated %d VMs & %d Resource Pools)",
 			stateLabel,
 			numWithOldBackups,
+			numCurrentBackups,
+			len(evaluatedVMs),
+			len(rps),
+		)
+
+	case numMissingBackups > 0:
+		return fmt.Sprintf(
+			"%s: %d VMs missing backups detected (%d present & %d current, evaluated %d VMs & %d Resource Pools)",
+			stateLabel,
+			numMissingBackups,
+			numWithBackups,
 			numCurrentBackups,
 			len(evaluatedVMs),
 			len(rps),


### PR DESCRIPTION
The main plugin logic considers old backups to a higher priority,
but the one-line summary logic focused on missing backups first.
This commit switches that logic for one-line summary output and
explicitly notes the decision within the main plugin file.

refs GH-506