### PR TITLE
Change default backup date format

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -137,7 +137,7 @@ const (
 	defaultVMBackupDateWarning                   int     = 1
 	defaultVMBackupDateCustomAttribute           string  = "Last Backup"
 	defaultVMBackupMetadataCustomAttribute       string  = "" // e.g., "Backup Status"
-	defaultVMBackupDateFormat                    string  = "2006-01-02 3:04:05 PM"
+	defaultVMBackupDateFormat                    string  = "01/02/2006 15:04:05"
 	defaultVMBackupDateTimezone                  string  = "Local"
 
 	// The default values are intentionally invalid to help determine whether


### PR DESCRIPTION
Update the default format from `2006-01-02 3:04:05 PM` to
`01/02/2006 15:04:05`. This matches the format of the sample
date/time value noted by the requestor (@tubby1981).

As before, this value can be overridden as desired to match the
format used by the specific VMware environment.

refs GH-506