### PR TITLE
Removing references to ignoring Custom Attributes

### DIFF
--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -132,7 +132,6 @@ func main() {
 		Int("backup_age_critical", cfg.VMBackupDateCritical).
 		Int("backup_age_warning", cfg.VMBackupDateWarning).
 		Bool("eval_powered_off", cfg.PoweredOff).
-		Bool("ignore_missing_ca_on_objects", cfg.IgnoreMissingCustomAttribute).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")
@@ -277,7 +276,6 @@ func main() {
 		cfg.VMBackupDateFormat,
 		cfg.VMBackupDateCritical,
 		cfg.VMBackupDateWarning,
-		cfg.IgnoreMissingCustomAttribute,
 	)
 	if vmsLookupErr != nil {
 

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -836,7 +836,6 @@ func GetVMsWithBackup(
 	backupDateFormat string,
 	criticalAgeThreshold int,
 	warningAgeThreshold int,
-	ignoreMissingCAs bool,
 ) (VMsWithBackup, error) {
 
 	funcTimeStart := time.Now()


### PR DESCRIPTION
- remove field from logger
- remove (inert) argument/parameter to
  `vsphere.GetVMsWithBackup()`

refs GH-506