### PR TITLE
Remove Title case for Custom Attributes term

### DIFF
--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -280,11 +280,11 @@ func main() {
 	if vmsLookupErr != nil {
 
 		log.Error().Err(vmsLookupErr).
-			Msg("error retrieving virtual machines with requested backup Custom Attributes")
+			Msg("error retrieving virtual machines with requested backup custom attributes")
 
 		nagiosExitState.LastError = vmsLookupErr
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
-			"%s: Error retrieving virtual machines with requested backup Custom Attributes",
+			"%s: Error retrieving virtual machines with requested backup custom attributes",
 			nagios.StateCRITICALLabel,
 		)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -34,7 +34,7 @@ const (
 	datastoreCustomAttributePrefixSeparatorFlagHelp string = "Custom Attribute prefix separator specific to datastores. Skip if using Custom Attribute values as-is for comparison, otherwise optional if specifying shared custom attribute prefix separator, or using the default separator."
 	sharedCustomAttributeNameFlagHelp               string = "Custom Attribute name for host ESXi systems and datastores. Optional if specifying resource-specific custom attribute names."
 	sharedCustomAttributePrefixSeparatorFlagHelp    string = "Custom Attribute prefix separator for host ESXi systems and datastores. Skip if using Custom Attribute values as-is for comparison, otherwise optional if specifying resource-specific custom attribute prefix separator, or using the default separator."
-	ignoreMissingCustomAttributeFlagHelp            string = "Toggles how missing Custom Attributes will be handled. By default, applicable vSphere objects missing specified Custom Attribute(s) are treated as an error condition."
+	ignoreMissingCustomAttributeFlagHelp            string = "Toggles how missing custom attributes will be handled. By default, applicable vSphere objects missing specified Custom Attribute(s) are treated as an error condition."
 	ignoreDatastoreFlagHelp                         string = "Specifies a comma-separated list of Datastore names that should be ignored or excluded from evaluation."
 	datastoreNameFlagHelp                           string = "Datastore name as it is found within the vSphere inventory."
 	datastoreSpaceUsageCriticalFlagHelp             string = "Specifies the percentage of a datastore's space usage (as a whole number) when a CRITICAL threshold is reached."

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -781,12 +781,12 @@ func GetVMsWithCAs(vms []mo.VirtualMachine) ([]VMWithCAs, error) {
 		// vsphere admin wishes to do so.
 		case errors.Is(err, ErrCustomAttributeNotSet):
 
-			logger.Printf("Custom Attributes for virtual machine %q missing",
+			logger.Printf("Custom attributes for virtual machine %q missing",
 				vm.Name,
 			)
 
 			logger.Printf(
-				"Adding VM %s to collection with empty Custom Attributes map",
+				"Adding VM %s to collection with empty custom attributes map",
 				vm.Name,
 			)
 			vmsWithAllCAs = append(vmsWithAllCAs, VMWithCAs{


### PR DESCRIPTION
Since the official documentation does not use Title case, update
log and user-facing output to not use it either.

There remain many doc comments with the term in Title case which
can be separately reviewed and updated as appropriate.

refs GH-506