### PR TITLE
Rename backup age threshold flags

### DIFF
--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -129,8 +129,8 @@ func main() {
 		Str("included_resource_pools", cfg.IncludedResourcePools.String()).
 		Str("excluded_resource_pools", cfg.ExcludedResourcePools.String()).
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
-		Int("backup_age_critical", cfg.VMBackupDateCritical).
-		Int("backup_age_warning", cfg.VMBackupDateWarning).
+		Int("backup_age_critical", cfg.VMBackupAgeCritical).
+		Int("backup_age_warning", cfg.VMBackupAgeWarning).
 		Bool("eval_powered_off", cfg.PoweredOff).
 		Logger()
 
@@ -274,8 +274,8 @@ func main() {
 		cfg.VMBackupDateCustomAttribute,
 		cfg.VMBackupMetadataCustomAttribute,
 		cfg.VMBackupDateFormat,
-		cfg.VMBackupDateCritical,
-		cfg.VMBackupDateWarning,
+		cfg.VMBackupAgeCritical,
+		cfg.VMBackupAgeWarning,
 	)
 	if vmsLookupErr != nil {
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -759,11 +759,11 @@ type Config struct {
 
 	// VMBackupAgeWarning specifies the number of days since the last backup
 	// for a VM when a WARNING threshold is reached.
-	VMBackupDateWarning int
+	VMBackupAgeWarning int
 
-	// VMBackupDateCritical specifies the number of days since the last backup
+	// VMBackupAgeCritical specifies the number of days since the last backup
 	// for a VM when a CRITICAL threshold is reached.
-	VMBackupDateCritical int
+	VMBackupAgeCritical int
 
 	// VirtualHardwareMinimumVersion is the minimum virtual hardware version
 	// accepted for each Virtual Machine. Any Virtual Machine not meeting this

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -65,8 +65,8 @@ const (
 	hostSystemNameFlagHelp                          string = "ESXi host/server name as it is found within the vSphere inventory."
 	hostSystemCPUUseCriticalFlagHelp                string = "Specifies the percentage of CPU use (as a whole number) when a CRITICAL threshold is reached."
 	hostSystemCPUUseWarningFlagHelp                 string = "Specifies the percentage of CPU use (as a whole number) when a WARNING threshold is reached."
-	vmBackupDateCriticalFlagHelp                    string = "Specifies the number of days since the last backup for a VM when a CRITICAL threshold is reached."
-	vmBackupDateWarningFlagHelp                     string = "Specifies the number of days since the last backup for a VM when a WARNING threshold is reached."
+	vmBackupAgeCriticalFlagHelp                     string = "Specifies the number of days since the last backup for a VM when a CRITICAL threshold is reached."
+	vmBackupAgeWarningFlagHelp                      string = "Specifies the number of days since the last backup for a VM when a WARNING threshold is reached."
 	vmBackupDateCustomAttributeFlagHelp             string = "Specifies the Custom Attribute used by Virtual Machine backup software to record when the Last Backup occurred."
 	vmBackupMetadataCustomAttributeFlagHelp         string = "Specifies the (optional) Custom Attribute used by Virtual Machine backup software to record metadata / details for the last backup. If provided, this value is used in log messages and the final report."
 	vmBackupDateFormatFlagHelp                      string = "Specifies the format of the date recorded when the Last Backup occurred. Defaults to the '2006-01-02 3:04:05 PM' layout if not overridden."
@@ -133,8 +133,8 @@ const (
 	defaultHostSystemName                        string  = ""
 	defaultVMPowerCycleUptimeCritical            int     = 90
 	defaultVMPowerCycleUptimeWarning             int     = 60
-	defaultVMBackupDateCritical                  int     = 2
-	defaultVMBackupDateWarning                   int     = 1
+	defaultVMBackupAgeCritical                   int     = 2
+	defaultVMBackupAgeWarning                    int     = 1
 	defaultVMBackupDateCustomAttribute           string  = "Last Backup"
 	defaultVMBackupMetadataCustomAttribute       string  = "" // e.g., "Backup Status"
 	defaultVMBackupDateFormat                    string  = "01/02/2006 15:04:05"

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -311,11 +311,11 @@ func (c *Config) handleFlagsConfig(pluginType PluginType) {
 		flag.StringVar(&c.VMBackupDateFormat, "backup-date-format", defaultVMBackupDateFormat, vmBackupDateFormatFlagHelp)
 		flag.StringVar(&c.VMBackupDateTimezone, "backup-date-timezone", defaultVMBackupDateTimezone, vmBackupDateTimezoneFlagHelp)
 
-		flag.IntVar(&c.VMBackupDateWarning, "backup-date-warning", defaultVMBackupDateWarning, vmBackupDateWarningFlagHelp)
-		flag.IntVar(&c.VMBackupDateWarning, "bdw", defaultVMBackupDateWarning, vmBackupDateWarningFlagHelp+" (shorthand)")
+		flag.IntVar(&c.VMBackupAgeWarning, "backup-age-warning", defaultVMBackupAgeWarning, vmBackupAgeWarningFlagHelp)
+		flag.IntVar(&c.VMBackupAgeWarning, "baw", defaultVMBackupAgeWarning, vmBackupAgeWarningFlagHelp+" (shorthand)")
 
-		flag.IntVar(&c.VMBackupDateCritical, "backup-date-critical", defaultVMBackupDateCritical, vmBackupDateCriticalFlagHelp)
-		flag.IntVar(&c.VMBackupDateCritical, "bdc", defaultVMBackupDateCritical, vmBackupDateCriticalFlagHelp+" (shorthand)")
+		flag.IntVar(&c.VMBackupAgeCritical, "backup-age-critical", defaultVMBackupAgeCritical, vmBackupAgeCriticalFlagHelp)
+		flag.IntVar(&c.VMBackupAgeCritical, "bac", defaultVMBackupAgeCritical, vmBackupAgeCriticalFlagHelp+" (shorthand)")
 
 	}
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -748,21 +748,21 @@ func (c Config) validate(pluginType PluginType) error {
 			return fmt.Errorf("last backup date time zone not provided")
 		}
 
-		if c.VMBackupDateCritical < 1 {
+		if c.VMBackupAgeCritical < 1 {
 			return fmt.Errorf(
 				"invalid backup date age CRITICAL threshold number: %d",
-				c.VMBackupDateCritical,
+				c.VMBackupAgeCritical,
 			)
 		}
 
-		if c.VMBackupDateWarning < 1 {
+		if c.VMBackupAgeWarning < 1 {
 			return fmt.Errorf(
 				"invalid backup date age WARNING threshold number: %d",
-				c.VMBackupDateWarning,
+				c.VMBackupAgeWarning,
 			)
 		}
 
-		if c.VMBackupDateCritical <= c.VMBackupDateWarning {
+		if c.VMBackupAgeCritical <= c.VMBackupAgeWarning {
 			return fmt.Errorf(
 				"critical threshold set lower than or equal to warning threshold",
 			)


### PR DESCRIPTION
Replace "backup date" with "backup age" to stress that the
purpose of the threshold flags are intended to handle
specifying age of backups, not specific dates.

This commit updates flag names, internal field names, etc.

refs GH-506