### PR TITLE
Fix resource pool inclusion/exclusion logic

### DIFF
--- a/internal/vsphere/datacenters.go
+++ b/internal/vsphere/datacenters.go
@@ -146,7 +146,7 @@ func GetDatacenters(ctx context.Context, c *vim25.Client, dcNames []string, prop
 	// Fetch all visible datacenters.
 	var allDCs []mo.Datacenter
 
-	err := getObjects(ctx, c, &allDCs, c.ServiceContent.RootFolder, propsSubset)
+	err := getObjects(ctx, c, &allDCs, c.ServiceContent.RootFolder, propsSubset, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve all Datacenters: %w", err)
 	}

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -990,7 +990,7 @@ func GetDatastores(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo
 		)
 	}(&dss)
 
-	err := getObjects(ctx, c, &dss, c.ServiceContent.RootFolder, propsSubset)
+	err := getObjects(ctx, c, &dss, c.ServiceContent.RootFolder, propsSubset, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve Datastores: %w", err)
 	}

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -112,7 +112,14 @@ func getAlarmPropsSubset() []string {
 // getObjects retrieves one or more objects, filtered by the provided
 // container type ManagedObjectReference. An error is returned if the provided
 // ManagedObjectReference is not for a supported container type.
-func getObjects(ctx context.Context, c *vim25.Client, dst interface{}, objRef types.ManagedObjectReference, propsSubset bool) error {
+func getObjects(
+	ctx context.Context,
+	c *vim25.Client,
+	dst interface{},
+	objRef types.ManagedObjectReference,
+	propsSubset bool,
+	recursive bool,
+) error {
 
 	funcTimeStart := time.Now()
 
@@ -254,7 +261,7 @@ func getObjects(ctx context.Context, c *vim25.Client, dst interface{}, objRef ty
 		ctx,
 		objRef,
 		[]string{objKind},
-		true,
+		recursive,
 	)
 	if err != nil {
 		return err

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -219,7 +219,7 @@ func GetHostSystems(ctx context.Context, c *vim25.Client, propsSubset bool) ([]m
 		)
 	}(&hss)
 
-	err := getObjects(ctx, c, &hss, c.ServiceContent.RootFolder, propsSubset)
+	err := getObjects(ctx, c, &hss, c.ServiceContent.RootFolder, propsSubset, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve HostSystems: %w", err)
 	}

--- a/internal/vsphere/networks.go
+++ b/internal/vsphere/networks.go
@@ -40,7 +40,7 @@ func GetNetworks(ctx context.Context, c *vim25.Client, propsSubset bool) ([]mo.N
 		)
 	}(&nets)
 
-	err := getObjects(ctx, c, &nets, c.ServiceContent.RootFolder, propsSubset)
+	err := getObjects(ctx, c, &nets, c.ServiceContent.RootFolder, propsSubset, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve host systems: %w", err)
 	}


### PR DESCRIPTION
## Changes

- allow `getObjects()` to conditionally allow recursive retrieval
    - update all calls to `getObjects()` to explicitly enable recursive
      retrieval of applicable vSphere objects
    - conditionally toggle recursive retrieval of virtual machines depending
      on whether they are for the `Resources` parent resource pool

- update `GetEligibleRPs()` so that it no longer checks for the `Resources`
  parent resource pool and handles it different than the others
  - move all "special case" logic to `GetVMsFromContainer()`

- update `GetVMsFromContainer()` to conditionally use recursive retrieval
  - if we are evaluating the `Resources` parent resource pool, use shallow,
    non-recursive retrieval so that we only pull in VMs at the top-level
  - if we are evaluating any other resource pool, retrieve recursively
  - we retain the deduplication step in case nested resource pools are
    processed so that we don't include a VM twice

## References

- fixes GH-600

See also:

- GH-399
  - GH-404
- GH-494
  - GH-495