### PR TITLE
Remove invalid power state eval field from logger

### DIFF
--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -131,7 +131,6 @@ func main() {
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
 		Int("backup_age_critical", cfg.VMBackupAgeCritical).
 		Int("backup_age_warning", cfg.VMBackupAgeWarning).
-		Bool("eval_powered_off", cfg.PoweredOff).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")


### PR DESCRIPTION
This plugin evaluates both powered off & on VMs equivalently, so
providing this logger field based on a non-existent user choice
(this plugin does not accept a flag to toggle power state eval)
is likely confusing.

Opting to remove it vs hard-coding the value.

fixes GH-602