### PR TITLE
Remove invalid power state eval field from logger

### DIFF
--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -118,7 +118,6 @@ func main() {
 		Str("included_resource_pools", cfg.IncludedResourcePools.String()).
 		Str("excluded_resource_pools", cfg.ExcludedResourcePools.String()).
 		Str("ignored_vms", cfg.IgnoredVMs.String()).
-		Bool("eval_powered_off", cfg.PoweredOff).
 		Logger()
 
 	log.Debug().Msg("Logging into vSphere environment")


### PR DESCRIPTION
This plugin evaluates both powered off & on VMs equivalently, so
providing this logger field based on a non-existent user choice
(this plugin does not accept a flag to toggle power state eval)
is likely confusing.

Opting to remove it vs hard-coding the value.

fixes GH-603