### PR TITLE
Enable all BUT fieldalignment govet analyzer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,8 @@ linters:
 
 linters-settings:
   govet:
+    enable-all: true
+
     #
     # Disable fieldalignment settings until the Go team offers more control over
     # the types of checks provided by the fieldalignment linter or golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,18 +37,17 @@ linters:
     - stylecheck
     - unconvert
 
-#
-# Disable fieldalignment settings until the Go team offers more control over
-# the types of checks provided by the fieldalignment linter or golangci-lint
-# does so.
-#
-# See https://github.com/atc0005/go-ci/issues/302 for more information.
-#
+  # disable:
+  # - maligned
 
-# disable:
-# - maligned
-
-# linters-settings:
-# govet:
-#   enable:
-#     - fieldalignment
+linters-settings:
+  govet:
+    #
+    # Disable fieldalignment settings until the Go team offers more control over
+    # the types of checks provided by the fieldalignment linter or golangci-lint
+    # does so.
+    #
+    # See https://github.com/atc0005/go-ci/issues/302 for more information.
+    #
+    disable:
+      - fieldalignment


### PR DESCRIPTION
The `fieldanalyzer` linter  does not yet offer a way (afaik) to disable the "pointer bytes" diagnostic, so we're still relying on the deprecated `maligned` linter for struct field size ordering.

We enable all other analyzers which are not otherwise explicitly excluded.

fixes GH-611