### PR TITLE
Fix `nilness` & `shadow` `govet` analyzer warnings

### DIFF
--- a/internal/vsphere/attributes.go
+++ b/internal/vsphere/attributes.go
@@ -266,7 +266,7 @@ func GetObjectCustomAttribute(obj mo.ManagedEntity, customAttributeName string, 
 			caVal = CustomAttributeValNotSet
 
 		// custom attributes are set, but some other error occurred
-		case caValErr != nil:
+		default:
 			logger.Printf(
 				"error retrieving value for provided Custom Attribute %q: %v",
 				customAttributeName,

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -274,6 +274,8 @@ func getObjects(
 		// A best practice when using views is to call the DestroyView()
 		// method when a view is no longer needed. This practice frees memory
 		// on the server.
+		//
+		// nolint:govet // err intentionally scoped; shadowing not a concern.
 		if err := v.Destroy(ctx); err != nil {
 			logger.Printf("Error occurred while destroying view: %s", err)
 		}

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1073,7 +1073,7 @@ func NewSnapshotSummarySet(
 					removeFileKey(&snapshotDiskFileKeys, key)
 				}
 
-			case parent != nil:
+			default:
 
 				// Parent snapshot is present. Remove all parent snapshot file
 				// keys from the list of snapshot file keys. This leaves only

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -2067,10 +2067,6 @@ func VMBackupViaCAOneLineCheckSummary(
 
 	switch {
 	case numWithOldBackups > 0:
-		numCurrentBackups := numWithBackups - numWithOldBackups
-		if numCurrentBackups < 0 {
-			numCurrentBackups = 0
-		}
 		return fmt.Sprintf(
 			"%s: %d VMs with old backups detected (%d current, evaluated %d VMs & %d Resource Pools)",
 			stateLabel,


### PR DESCRIPTION
- ignore shadowing warning for `err` variable within if statement
  that wraps deferred view destruction
  - alternative here is to use a name error return value and
    return the view destruction failure result if `err` is not
    already set to another value
  - library devs don't check the error return value for the
    view destruction attempt, which signals to me that the risk
    of it failing is very, very low
- fix unintentional shadowing (essentially "NOOP" scenario) from
  minor refactoring
- replace explicit case statements with default case to resolve
  "tautological" conditions

fixes GH-613