### PR TITLE
Fix hard-coded (and mostly incorrect) obj types

### DIFF
--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -278,7 +278,8 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 		ca, err := GetObjectCustomAttribute(host.ManagedEntity, hostCustomAttributeName, ignoreMissingCA)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"failed to retrieve custom attribute for VM %s: %w",
+				"failed to retrieve custom attribute for %s %s: %w",
+				host.ManagedEntity.Self.Type,
 				host.Name,
 				err,
 			)
@@ -359,7 +360,8 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 		ca, err := GetObjectCustomAttribute(ds.ManagedEntity, dsCustomAttributeName, ignoreMissingCA)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"failed to retrieve custom attribute for VM %s: %w",
+				"failed to retrieve custom attribute for %s %s: %w",
+				ds.ManagedEntity.Self.Type,
 				ds.Name,
 				err,
 			)

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -741,7 +741,8 @@ func GetVMsWithCA(vms []mo.VirtualMachine, vmCustomAttributeName string, ignoreM
 		ca, err := GetObjectCustomAttribute(vm.ManagedEntity, vmCustomAttributeName, ignoreMissingCA)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"failed to retrieve custom attribute for VM %s: %w",
+				"failed to retrieve custom attribute for %s %s: %w",
+				vm.ManagedEntity.Self.Type,
 				vm.Name,
 				err,
 			)
@@ -799,7 +800,8 @@ func GetVMsWithCAs(vms []mo.VirtualMachine) ([]VMWithCAs, error) {
 		// Custom attributes are set, but some other error occurred
 		case err != nil:
 			return nil, fmt.Errorf(
-				"failed to retrieve custom attributes for %s: %w",
+				"failed to retrieve custom attribute for %s %s: %w",
+				vm.ManagedEntity.Self.Type,
 				vm.Name,
 				err,
 			)


### PR DESCRIPTION
- replace incorrect copy/paste object types mentioned
  in CA retrieval error message strings
- replace hard-coded object type mentioned in CA retrieval
  error message strings

refs GH-636