### PR TITLE
Expose CA for Hosts, Datastores in mismatch report

### DIFF
--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -1343,6 +1343,37 @@ func VMNames(vmsList []mo.VirtualMachine) []string {
 
 }
 
+// getVMHostID retrieves the VM host MOID value for a specified VM. If the
+// host MOID value is not available an error is returned. The host MOID value
+// may be unavailable if the service account executing the plugin does not
+// have sufficient permissions.
+func getVMHostID(vm mo.VirtualMachine) (string, error) {
+	switch {
+
+	case vm.Runtime.Host == nil:
+		return "", fmt.Errorf(
+			"error retrieving associated Host MOID for VM %s: %w",
+			vm.Name,
+			ErrManagedObjectIDIsNil,
+		)
+
+	case vm.Runtime.Host.Value == "":
+		return "", fmt.Errorf(
+			"error retrieving associated Host MOID for VM %s: %w",
+			vm.Name,
+			ErrManagedObjectIDIsEmpty,
+		)
+
+	default:
+
+		// Safe to reference now that we have guarded against potential
+		// nil Host field pointer and empty MOID.
+
+		return vm.Runtime.Host.Value, nil
+
+	}
+}
+
 // GetVMPowerCycleUptimeStatusSummary accepts a list of VirtualMachines and
 // threshold values and generates a collection of VirtualMachines that exceeds
 // given thresholds along with those given thresholds.


### PR DESCRIPTION
## Summary

Apply changes in order to expose Custom Attribute used to identify
mismatched Hosts / Datastores / Virtual Machines.

This includes (at a high level):

- list Custom Attribute for Host and Datastore entries
- explicitly indicate which value is the Host and which values are
  Datastores (intended to clarify at a glance where the problem lies)

Other (internal) changes worth noting for my future self:

- replace `VMToMismatchedDatastoreNames`index which provided limited
  datastore details with `VMToMismatchedPairing` index which provides
  `HostWithCA` and `[]DatastoreWithCA` in order to expose full details
  to better support logging and reporting purposes
- update functions/methods to compose the new type
- refactor related functions/methods to improve logging, simplify
  logic

 More refactoring remains to be done later, but this was a useful step
 in that direction.

## References

- fixes GH-635
