### PR TITLE
Emit ballooned, swapped memory performance data

### DIFF
--- a/docs/plugins/check_vmware_rps_memory.md
+++ b/docs/plugins/check_vmware_rps_memory.md
@@ -61,6 +61,8 @@ any feedback that you may have. Thanks in advance!
 - `memory_usage`
 - `memory_used`
 - `memory_remaining`
+- `memory_ballooned`
+- `memory_swapped`
 - `resource_pools_excluded`
 - `resource_pools_included`
 - `resource_pools_evaluated`


### PR DESCRIPTION
Refactor collection of Resource Pool memory usage via "quick stats" and extend to provide ballooned memory and swapped memory statistics. Emit as additional perfdata metrics and debug logging output.

I've held off emitting the details via `LongServiceOutput` for the time being.

Plugin documentation updated to note new perfdata metrics:

- `memory_ballooned`
- `memory_swapped`

The `vsphere.ResourcePoolsMemoryReport()` func was updated to drop an unused argument (likely a leftover from a previous refactor).

refs GH-643
fixes GH-644
fixes GH-652