### PR TITLE
Fix invalid aggregate memory usage calculation

### DIFF
--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -383,7 +383,7 @@ func ResourcePoolStats(ctx context.Context, client *vim25.Client, resourcePools 
 		// pressure on the host. We multiply by units.MB in order to get the
 		// number of bytes.
 		rpBalloonedMemory := rpSummary.QuickStats.BalloonedMemory * units.MB
-		aggregateMemoryUsageInBytes += rpMemoryUsage
+		aggregateBalloonedMemoryInBytes += rpBalloonedMemory
 
 		rpSwappedMemory := rpSummary.QuickStats.SwappedMemory * units.MB
 		aggregateSwappedMemoryInBytes += rpSwappedMemory


### PR DESCRIPTION
Prior calculation incorrectly doubled the actual memory usage instead of accumulating ballooned memory usage as intended.

Thanks to @aucompbiker for reporting the issue.

fixes GH-668