### PR TITLE
Fix various atc0005/go-nagios usage linting errors

### DIFF
--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -135,7 +135,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -171,7 +171,7 @@ func main() {
 			"error retrieving requested datastore",
 		)
 
-		nagiosExitState.LastError = dsFetchErr
+		nagiosExitState.AddError(dsFetchErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving datastore %q",
 			nagios.StateCRITICALLabel,
@@ -191,7 +191,7 @@ func main() {
 			Str("reasons", strings.Join(dsInaccessibleReasons, ", ")).
 			Msg("datastore is inaccessible")
 
-		nagiosExitState.LastError = dsAccessibilityErr
+		nagiosExitState.AddError(dsAccessibilityErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Datastore %q is inaccessible due to: [%s]",
 			nagios.StateCRITICALLabel,
@@ -218,7 +218,7 @@ func main() {
 			"error generating datastore usage summary",
 		)
 
-		nagiosExitState.LastError = dsSpaceUsageErr
+		nagiosExitState.AddError(dsSpaceUsageErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error generating summary for datastore %q",
 			nagios.StateCRITICALLabel,
@@ -302,7 +302,7 @@ func main() {
 
 		log.Error().Msg("Datastore usage CRITICAL")
 
-		nagiosExitState.LastError = vsphere.ErrDatastoreSpaceUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrDatastoreSpaceUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.DatastoreSpaceUsageOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -328,7 +328,7 @@ func main() {
 
 		log.Error().Msg("Datastore usage WARNING")
 
-		nagiosExitState.LastError = vsphere.ErrDatastoreSpaceUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrDatastoreSpaceUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.DatastoreSpaceUsageOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -353,8 +353,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("Datastore usage within specified thresholds")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.DatastoreSpaceUsageOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -123,7 +123,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -153,7 +153,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -176,7 +176,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -207,7 +207,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -264,7 +264,7 @@ func main() {
 				"error triggering state reload for VMs",
 			)
 
-			nagiosExitState.LastError = err
+			nagiosExitState.AddError(err)
 			nagiosExitState.ServiceOutput = fmt.Sprintf(
 				"%s: Error triggering state reload for VMs",
 				nagios.StateCRITICALLabel,
@@ -350,7 +350,7 @@ func main() {
 			Str("virtual_machines", vmsList).
 			Msg("Virtual Machines found in need of disk consolidation")
 
-		nagiosExitState.LastError = vsphere.ErrVirtualMachineDiskConsolidationNeeded
+		nagiosExitState.AddError(vsphere.ErrVirtualMachineDiskConsolidationNeeded)
 
 		nagiosExitState.ServiceOutput = vsphere.VMDiskConsolidationOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -386,8 +386,6 @@ func main() {
 		// success path
 
 		log.Debug().Msg("VirtualMachine disk consolidation not needed")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.VMDiskConsolidationOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -135,7 +135,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -171,7 +171,7 @@ func main() {
 			"error retrieving requested host",
 		)
 
-		nagiosExitState.LastError = hsFetchErr
+		nagiosExitState.AddError(hsFetchErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving host %q",
 			nagios.StateCRITICALLabel,
@@ -192,7 +192,7 @@ func main() {
 	if hsUsageErr != nil {
 		log.Error().Err(hsUsageErr).Msg("error creating host CPU usage summary")
 
-		nagiosExitState.LastError = hsUsageErr
+		nagiosExitState.AddError(hsUsageErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error creating host CPU usage summary",
 			nagios.StateCRITICALLabel,
@@ -220,7 +220,7 @@ func main() {
 			"error retrieving VirtualMachines on host",
 		)
 
-		nagiosExitState.LastError = hsVMsFetchErr
+		nagiosExitState.AddError(hsVMsFetchErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving VirtualMachines on host %q",
 			nagios.StateCRITICALLabel,
@@ -309,7 +309,7 @@ func main() {
 			Str("host_name", hostSystem.Name).
 			Msg("host CPU usage threshold crossed")
 
-		nagiosExitState.LastError = vsphere.ErrHostSystemCPUUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrHostSystemCPUUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemCPUUsageOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -337,7 +337,7 @@ func main() {
 
 		log.Error().Msg("host CPU usage threshold crossed")
 
-		nagiosExitState.LastError = vsphere.ErrHostSystemCPUUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrHostSystemCPUUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemCPUUsageOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -364,8 +364,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("Host CPU usage thresholds not exceeded")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemCPUUsageOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -56,7 +56,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -81,7 +81,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -136,7 +136,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -172,7 +172,7 @@ func main() {
 			"error retrieving requested host",
 		)
 
-		nagiosExitState.LastError = hsFetchErr
+		nagiosExitState.AddError(hsFetchErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving host %q",
 			nagios.StateCRITICALLabel,
@@ -193,7 +193,7 @@ func main() {
 	if hsUsageErr != nil {
 		log.Error().Err(hsUsageErr).Msg("error creating host memory usage summary")
 
-		nagiosExitState.LastError = hsUsageErr
+		nagiosExitState.AddError(hsUsageErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error creating host memory usage summary",
 			nagios.StateCRITICALLabel,
@@ -221,7 +221,7 @@ func main() {
 			"error retrieving VirtualMachines on host",
 		)
 
-		nagiosExitState.LastError = hsVMsFetchErr
+		nagiosExitState.AddError(hsVMsFetchErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving VirtualMachines on host %q",
 			nagios.StateCRITICALLabel,
@@ -308,7 +308,7 @@ func main() {
 
 		log.Error().Msg("host memory usage threshold crossed")
 
-		nagiosExitState.LastError = vsphere.ErrHostSystemMemoryUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrHostSystemMemoryUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemMemoryUsageOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -336,7 +336,7 @@ func main() {
 
 		log.Error().Msg("host memory usage threshold crossed")
 
-		nagiosExitState.LastError = vsphere.ErrHostSystemMemoryUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrHostSystemMemoryUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemMemoryUsageOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -363,8 +363,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("Host memory usage thresholds not exceeded")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.HostSystemMemoryUsageOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -56,7 +56,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -81,7 +81,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -129,7 +129,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -159,7 +159,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -182,7 +182,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -213,7 +213,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -251,7 +251,7 @@ func main() {
 			"error retrieving list of datastores",
 		)
 
-		nagiosExitState.LastError = dssErr
+		nagiosExitState.AddError(dssErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of datastores",
 			nagios.StateCRITICALLabel,
@@ -274,7 +274,7 @@ func main() {
 			Str("custom_attribute_name", dsCustomAttributeName).
 			Msg("error retrieving datastores with specified Custom Attribute")
 
-		nagiosExitState.LastError = dsLookupErr
+		nagiosExitState.AddError(dsLookupErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving datastores with Custom Attribute %q",
 			nagios.StateCRITICALLabel,
@@ -301,7 +301,7 @@ func main() {
 			"error retrieving list of hosts",
 		)
 
-		nagiosExitState.LastError = hsErr
+		nagiosExitState.AddError(hsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of hosts",
 			nagios.StateCRITICALLabel,
@@ -323,7 +323,7 @@ func main() {
 			Str("custom_attribute_name", hostCustomAttributeName).
 			Msg("error retrieving hosts with specified Custom Attribute")
 
-		nagiosExitState.LastError = hostsLookupErr
+		nagiosExitState.AddError(hostsLookupErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving hosts with Custom Attribute %q",
 			nagios.StateCRITICALLabel,
@@ -346,7 +346,7 @@ func main() {
 	}
 
 	// Create host-to-datastore index for *all* hosts and datastores, even
-	// where a host has no matching datastores (via specificied literal or
+	// where a host has no matching datastores (via specified literal or
 	// prefix custom attribute values).
 	h2dIdx, h2dIdxErr := vsphere.NewHostToDatastoreIndex(
 		hostsWithCAs,
@@ -378,7 +378,7 @@ func main() {
 			dsCustomAttributeName,
 		)
 
-		nagiosExitState.LastError = h2dIdxErr
+		nagiosExitState.AddError(h2dIdxErr)
 
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
@@ -416,7 +416,7 @@ func main() {
 
 		log.Error().Err(lookupErr).Msg(errMsg)
 
-		nagiosExitState.LastError = lookupErr
+		nagiosExitState.AddError(lookupErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: %s",
 			nagios.StateCRITICALLabel,
@@ -499,7 +499,7 @@ func main() {
 			Str("mismatched_vms_list", strings.Join(vmNames, ", ")).
 			Msg("VM/Host/Datastore validation failed")
 
-		nagiosExitState.LastError = vsphere.ErrVMDatastoreNotInVMHostPairedList
+		nagiosExitState.AddError(vsphere.ErrVMDatastoreNotInVMHostPairedList)
 
 		nagiosExitState.ServiceOutput = vsphere.H2D2VMsOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -541,8 +541,6 @@ func main() {
 		// success if we made it here
 
 		log.Debug().Msg("No mismatched Host/Datastore/VM pairings detected")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.H2D2VMsOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 	// Disable library debug logging output by default
 	// vsphere.EnableLogging()
@@ -79,7 +79,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -122,7 +122,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -152,7 +152,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -175,7 +175,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -206,7 +206,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -314,7 +314,7 @@ func main() {
 			Str("virtual_machines", vmsList).
 			Msg("Virtual Machines found blocked by interactive question")
 
-		nagiosExitState.LastError = vsphere.ErrVirtualMachineInteractiveResponseNeeded
+		nagiosExitState.AddError(vsphere.ErrVirtualMachineInteractiveResponseNeeded)
 
 		nagiosExitState.ServiceOutput = vsphere.VMInteractiveQuestionOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -350,8 +350,6 @@ func main() {
 		// success path
 
 		log.Debug().Msg("No Virtual Machines blocked by interactive questions")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.VMInteractiveQuestionOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -56,7 +56,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -81,7 +81,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -140,7 +140,7 @@ func main() {
 			"%s: Error excluding default Resources Pool from evaluation",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = err
+		nagiosExitState.AddError(err)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -170,7 +170,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -200,7 +200,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -224,7 +224,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -251,7 +251,7 @@ func main() {
 			"error retrieving stats for resource pools",
 		)
 
-		nagiosExitState.LastError = rpStatsErr
+		nagiosExitState.AddError(rpStatsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving stats for resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -270,7 +270,7 @@ func main() {
 			"error retrieving hosts memory capacity",
 		)
 
-		nagiosExitState.LastError = getMemErr
+		nagiosExitState.AddError(getMemErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving memory capacity of hosts from %q",
 			nagios.StateCRITICALLabel,
@@ -329,7 +329,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -411,7 +411,7 @@ func main() {
 
 		log.Error().Msg("memory usage critical")
 
-		nagiosExitState.LastError = vsphere.ErrResourcePoolMemoryUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrResourcePoolMemoryUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.RPMemoryUsageOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -445,7 +445,7 @@ func main() {
 
 		log.Error().Msg("memory usage warning")
 
-		nagiosExitState.LastError = vsphere.ErrResourcePoolMemoryUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrResourcePoolMemoryUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.RPMemoryUsageOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -478,8 +478,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("memory usage ok")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.RPMemoryUsageOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -131,7 +131,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -161,7 +161,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -184,7 +184,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -215,7 +215,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -350,7 +350,7 @@ func main() {
 		log.Error().
 			Msg("Snapshot sets contain a snapshot which exceeds specified age in days")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotAgeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -389,7 +389,7 @@ func main() {
 		log.Error().
 			Msg("Snapshot sets contain one or more snapshots which exceed specified age in days")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotAgeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotAgeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -426,8 +426,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("No snapshots found which exceed specified age in days")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsAgeOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -131,7 +131,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -161,7 +161,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -184,7 +184,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -215,7 +215,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -354,7 +354,7 @@ func main() {
 			Int("num_snapshots_in_excess", numExcessSnaps).
 			Msg("Snapshot sets exceed number of specified (permitted) snapshots per VM")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotCountThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotCountThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -397,7 +397,7 @@ func main() {
 			Int("num_snapshots_in_excess", numExcessSnaps).
 			Msg("Snapshot sets exceed number of specified (permitted) snapshots per VM")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotCountThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotCountThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -434,8 +434,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("No VMs found with snapshots exceeding specified count")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsCountOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -131,7 +131,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -161,7 +161,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -184,7 +184,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -215,7 +215,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -354,7 +354,7 @@ func main() {
 			Int("num_snapshots_size_critical", largeSnapshots).
 			Msg("Snapshot sets contain a snapshot which exceeds specified size in GB")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotSizeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -397,7 +397,7 @@ func main() {
 			Int("num_snapshots_size_warning", largeSnapshots).
 			Msg("Snapshot sets contain a snapshot which exceeds specified size in GB")
 
-		nagiosExitState.LastError = vsphere.ErrSnapshotSizeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrSnapshotSizeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -432,8 +432,6 @@ func main() {
 		return
 
 	default:
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.SnapshotsSizeOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -128,7 +128,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -158,7 +158,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -181,7 +181,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -212,7 +212,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -311,11 +311,11 @@ func main() {
 
 		serviceState := vsphere.GetVMToolsStatusSummary(vmsWithIssues)
 
-		nagiosExitState.LastError = fmt.Errorf(
+		nagiosExitState.AddError(fmt.Errorf(
 			"%d of %d VMs with VMware Tools issues",
 			len(vmsWithIssues),
 			len(filteredVMs),
-		)
+		))
 
 		nagiosExitState.ServiceOutput = vsphere.VMToolsOneLineCheckSummary(
 			serviceState.Label,
@@ -355,8 +355,6 @@ func main() {
 		Int("vms_with_issues", numVMsWithToolsIssues).
 		Int("vms_without_issues", numVMsWithoutToolsIssues).
 		Msg("No problems with VMware Tools found")
-
-	nagiosExitState.LastError = nil
 
 	nagiosExitState.ServiceOutput = vsphere.VMToolsOneLineCheckSummary(
 		nagios.StateOKLabel,

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -135,7 +135,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -165,7 +165,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -188,7 +188,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -219,7 +219,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -343,7 +343,7 @@ func main() {
 
 		log.Error().Msg("vCPUs allocation CRITICAL")
 
-		nagiosExitState.LastError = vsphere.ErrVCPUsUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrVCPUsUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.VirtualCPUsOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -380,7 +380,7 @@ func main() {
 
 		log.Error().Msg("vCPUs allocation WARNING")
 
-		nagiosExitState.LastError = vsphere.ErrVCPUsUsageThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrVCPUsUsageThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.VirtualCPUsOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -416,8 +416,6 @@ func main() {
 	default:
 
 		log.Debug().Msg("vCPUs allocation OK")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.VirtualCPUsOneLineCheckSummary(
 			nagios.StateOKLabel,

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -117,7 +117,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -147,7 +147,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -170,7 +170,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -201,7 +201,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -237,7 +237,7 @@ func main() {
 	if hwIdxErr != nil {
 		log.Error().Err(hwIdxErr).Msg("error creating virtual hardware index")
 
-		nagiosExitState.LastError = hwIdxErr
+		nagiosExitState.AddError(hwIdxErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error creating index of virtual hardware versions",
 			nagios.StateCRITICALLabel,
@@ -260,7 +260,7 @@ func main() {
 			"error retrieving default hardware version",
 		)
 
-		nagiosExitState.LastError = getDefVerErr
+		nagiosExitState.AddError(getDefVerErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving default hardware version",
 			nagios.StateCRITICALLabel,
@@ -355,7 +355,7 @@ func main() {
 
 			log.Error().Msg("Virtual Hardware versions inconsistency detected")
 
-			nagiosExitState.LastError = vsphere.ErrVirtualHardwareOutdatedVersionsFound
+			nagiosExitState.AddError(vsphere.ErrVirtualHardwareOutdatedVersionsFound)
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateWARNINGLabel,
@@ -394,8 +394,6 @@ func main() {
 			// same hardware version
 
 			log.Debug().Msg("Homogenous hardware versions found")
-
-			nagiosExitState.LastError = nil
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateOKLabel,
@@ -452,7 +450,7 @@ func main() {
 			log.Error().
 				Msg("Virtual Hardware versions older than the specified minimum version detected")
 
-			nagiosExitState.LastError = vsphere.ErrVirtualHardwareOutdatedVersionsFound
+			nagiosExitState.AddError(vsphere.ErrVirtualHardwareOutdatedVersionsFound)
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateCRITICALLabel,
@@ -489,8 +487,6 @@ func main() {
 		default:
 
 			log.Debug().Msg("Minimum hardware version met")
-
-			nagiosExitState.LastError = nil
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateOKLabel,
@@ -547,7 +543,7 @@ func main() {
 			log.Error().
 				Msg("Virtual Hardware versions older than the host or cluster default version detected")
 
-			nagiosExitState.LastError = vsphere.ErrVirtualHardwareOutdatedVersionsFound
+			nagiosExitState.AddError(vsphere.ErrVirtualHardwareOutdatedVersionsFound)
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateWARNINGLabel,
@@ -584,8 +580,6 @@ func main() {
 		default:
 
 			log.Debug().Msg("Default hardware version met")
-
-			nagiosExitState.LastError = nil
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateOKLabel,
@@ -647,7 +641,7 @@ func main() {
 			log.Error().
 				Msg("Virtual Hardware versions older than the specified minimum version detected")
 
-			nagiosExitState.LastError = vsphere.ErrVirtualHardwareOutdatedVersionsFound
+			nagiosExitState.AddError(vsphere.ErrVirtualHardwareOutdatedVersionsFound)
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateCRITICALLabel,
@@ -686,7 +680,7 @@ func main() {
 			log.Error().
 				Msg("Virtual Hardware versions older than the specified minimum version detected")
 
-			nagiosExitState.LastError = vsphere.ErrVirtualHardwareOutdatedVersionsFound
+			nagiosExitState.AddError(vsphere.ErrVirtualHardwareOutdatedVersionsFound)
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateWARNINGLabel,
@@ -724,8 +718,6 @@ func main() {
 
 			log.Debug().
 				Msg("Virtual Hardware versions meet the specified minimum version")
-
-			nagiosExitState.LastError = nil
 
 			nagiosExitState.ServiceOutput = vsphere.VirtualHardwareOneLineCheckSummary(
 				nagios.StateOKLabel,

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -55,7 +55,7 @@ func main() {
 
 		// Annotate errors (if applicable) with additional context to aid in
 		// troubleshooting.
-		nagiosExitState.LastError = vsphere.AnnotateError(nagiosExitState.LastError)
+		nagiosExitState.Errors = vsphere.AnnotateError(nagiosExitState.Errors...)
 	}(&nagiosExitState, pluginStart)
 
 	// Disable library debug logging output by default
@@ -80,7 +80,7 @@ func main() {
 			"%s: Error initializing application",
 			nagios.StateCRITICALLabel,
 		)
-		nagiosExitState.LastError = cfgErr
+		nagiosExitState.AddError(cfgErr)
 		nagiosExitState.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -129,7 +129,7 @@ func main() {
 	if loginErr != nil {
 		log.Error().Err(loginErr).Msgf("error logging into %s", cfg.Server)
 
-		nagiosExitState.LastError = loginErr
+		nagiosExitState.AddError(loginErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error logging into %q",
 			nagios.StateCRITICALLabel,
@@ -159,7 +159,7 @@ func main() {
 	if validateErr != nil {
 		log.Error().Err(validateErr).Msg("error validating include/exclude lists")
 
-		nagiosExitState.LastError = validateErr
+		nagiosExitState.AddError(validateErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error validating include/exclude lists",
 			nagios.StateCRITICALLabel,
@@ -182,7 +182,7 @@ func main() {
 			"error retrieving list of resource pools",
 		)
 
-		nagiosExitState.LastError = getRPsErr
+		nagiosExitState.AddError(getRPsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of resource pools from %q",
 			nagios.StateCRITICALLabel,
@@ -213,7 +213,7 @@ func main() {
 			"error retrieving list of VMs from resource pools list",
 		)
 
-		nagiosExitState.LastError = getVMsErr
+		nagiosExitState.AddError(getVMsErr)
 		nagiosExitState.ServiceOutput = fmt.Sprintf(
 			"%s: Error retrieving list of VMs from resource pools list",
 			nagios.StateCRITICALLabel,
@@ -301,7 +301,7 @@ func main() {
 			Str("virtual_machines_with_high_uptime", uptimeSummary.VMNames()).
 			Msg("VMs crossed power cycle uptime thresholds")
 
-		nagiosExitState.LastError = vsphere.ErrVirtualMachinePowerCycleUptimeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrVirtualMachinePowerCycleUptimeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.VMPowerCycleUptimeOneLineCheckSummary(
 			nagios.StateCRITICALLabel,
@@ -338,7 +338,7 @@ func main() {
 			Str("virtual_machines_with_high_uptime", uptimeSummary.VMNames()).
 			Msg("VMs crossed power cycle uptime thresholds")
 
-		nagiosExitState.LastError = vsphere.ErrVirtualMachinePowerCycleUptimeThresholdCrossed
+		nagiosExitState.AddError(vsphere.ErrVirtualMachinePowerCycleUptimeThresholdCrossed)
 
 		nagiosExitState.ServiceOutput = vsphere.VMPowerCycleUptimeOneLineCheckSummary(
 			nagios.StateWARNINGLabel,
@@ -374,8 +374,6 @@ func main() {
 		// success path
 
 		log.Debug().Msg("VM Power Cycle uptime thresholds not exceeded")
-
-		nagiosExitState.LastError = nil
 
 		nagiosExitState.ServiceOutput = vsphere.VMPowerCycleUptimeOneLineCheckSummary(
 			nagios.StateOKLabel,


### PR DESCRIPTION
- replace direct usage of `ExitState.LastError` field with
  `ExitState.AddError()` method calls
- drop recording of `nil` value as error state for OK
  result checks (a NOOP, but unnecessary and potential for
  future bugs)
- update AnnotateError() func to handle variadic list of
  errors (intended to handle `ExitState.Errors` collection)

refs GH-1109