### PR TITLE
Replace ampersand in plugin output

### DIFF
--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -960,7 +960,7 @@ func H2D2VMsReport(
 	case ignoreMissingCA:
 		fmt.Fprintf(
 			&report,
-			"* As requested, Hosts & Datastores with missing Custom Attribute are ignored [Host: %q, Datastore: %q]%s",
+			"* As requested, Hosts and Datastores with missing Custom Attribute are ignored [Host: %q, Datastore: %q]%s",
 			hostCAName,
 			datastoreCAName,
 			nagios.CheckOutputEOL,
@@ -969,7 +969,7 @@ func H2D2VMsReport(
 	default:
 		fmt.Fprintf(
 			&report,
-			"* As requested, Hosts & Datastores with missing Custom Attribute is a fatal condition [Host: %q, Datastore: %q]%s",
+			"* As requested, Hosts and Datastores with missing Custom Attribute is a fatal condition [Host: %q, Datastore: %q]%s",
 			hostCAName,
 			datastoreCAName,
 			nagios.CheckOutputEOL,

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -2101,7 +2101,7 @@ func VMBackupViaCAOneLineCheckSummary(
 	switch {
 	case numWithOldBackups > 0:
 		return fmt.Sprintf(
-			"%s: %d VMs with old backups detected (%d current, evaluated %d VMs & %d Resource Pools)",
+			"%s: %d VMs with old backups detected (%d current; evaluated %d VMs, %d Resource Pools)",
 			stateLabel,
 			numWithOldBackups,
 			numCurrentBackups,
@@ -2111,7 +2111,7 @@ func VMBackupViaCAOneLineCheckSummary(
 
 	case numMissingBackups > 0:
 		return fmt.Sprintf(
-			"%s: %d VMs missing backups detected (%d present & %d current, evaluated %d VMs & %d Resource Pools)",
+			"%s: %d VMs missing backups detected (%d present, %d current; evaluated %d VMs, %d Resource Pools)",
 			stateLabel,
 			numMissingBackups,
 			numWithBackups,
@@ -2123,7 +2123,7 @@ func VMBackupViaCAOneLineCheckSummary(
 	default:
 
 		return fmt.Sprintf(
-			"%s: No VMs with old or missing backups detected (%d present, evaluated %d VMs & %d Resource Pools)",
+			"%s: No VMs with old or missing backups detected (%d present; evaluated %d VMs, %d Resource Pools)",
 			stateLabel,
 			numCurrentBackups,
 			len(evaluatedVMs),


### PR DESCRIPTION
Replace the `&` character with the word `and` or by adjusting the formatting used with emitted metadata. This works around the Nagios `illegal_macro_output_chars` setting that results in the ampersand character being stripped out of plugin output.

fixes GH-679