### PR TITLE
Fix various doc Markdown linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,20 +370,4 @@ SOFTWARE.
 
 [go-docs-install]: <https://golang.org/doc/install>  "Install Go"
 
-[vsphere-managed-object-reference]: <https://vdc-download.vmware.com/vmwb-repository/dcr-public/a5f4000f-1ea8-48a9-9221-586adff3c557/7ff50256-2cf2-45ea-aacd-87d231ab1ac7/vmodl.ManagedObjectReference.html> "Data Object - ManagedObjectReference(vmodl.ManagedObjectReference)"
-
-[vsphere-manged-entity-status]: <https://vdc-repo.vmware.com/vmwb-repository/dcr-public/91f5f971-bf1d-4904-9942-37c6109da8a3/b79fa83f-dc4e-491d-9785-dc9d91aa0c67/doc/vim.ManagedEntity.Status.html>
-
-[vsphere-default-alarms]: <https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.monitoring.doc/GUID-82933270-1D72-4CF3-A1AF-E5A1343F62DE.html>
-
-[nagios-state-types]: <https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/statetypes.html>
-
-[vsphere-guestinfo-data-object]: <https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.vm.GuestInfo.html>
-
-[vsphere-query-datastore-performance-summary-method]: <https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.StorageResourceManager.html#queryDatastorePerformanceSummary>
-
-[vsphere-storage-performance-summary-data-object]: <https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.StorageResourceManager.StoragePerformanceSummary.html>
-
-[vsphere-storage-io-resource-management-data-object]: <https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.StorageResourceManager.IORMConfigInfo.html>
-
 <!-- []: PLACEHOLDER "DESCRIPTION_HERE" -->

--- a/docs/plugins/check_vmware_alarms.md
+++ b/docs/plugins/check_vmware_alarms.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -57,6 +58,16 @@ Filtering is available for explicitly *including* or *excluding* based on:
 - `Resource Pool` for the [Managed Entity
   type][vsphere-managed-object-reference] (e.g., `ResourcePool`,
   `VirtualMachine`) associated with the Triggered Alarm
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_datastore_performance.md
+++ b/docs/plugins/check_vmware_datastore_performance.md
@@ -12,6 +12,7 @@
   - [How datastore performance metrics are evaluated](#how-datastore-performance-metrics-are-evaluated)
   - [Performance Data metrics](#performance-data-metrics)
   - [Stability of this plugin](#stability-of-this-plugin)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -143,6 +144,16 @@ If you use this plugin, please provide feedback by [opening a new discussion
 thread](https://github.com/atc0005/check-vmware/discussions/new) or commenting
 on the original discussion thread [here
 (GH-316)](https://github.com/atc0005/check-vmware/discussions/316).
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_datastore_space.md
+++ b/docs/plugins/check_vmware_datastore_space.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -31,6 +32,16 @@ Nagios plugin used to monitor datastore space usage.
 In addition to reporting current datastore space usage, this plugin also
 reports which VMs reside on the datastore along with their percentage of the
 total datastore space used.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_disk_consolidation.md
+++ b/docs/plugins/check_vmware_disk_consolidation.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -60,6 +61,16 @@ This will be significantly faster than evaluating the state of each VM every
 time the associated service check executes and depending on the frequency of
 the job should be "fresh enough" to allow this plugin to accurately detect
 disk consolidation needs.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_host_cpu.md
+++ b/docs/plugins/check_vmware_host_cpu.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -35,6 +36,16 @@ as a fixed value and as a percentage of the host's total CPU capacity.
 Thresholds for `CRITICAL` and `WARNING` CPU usage have usable defaults, but
 may require adjustment for your environment. See the [configuration
 options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_host_memory.md
+++ b/docs/plugins/check_vmware_host_memory.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -35,6 +36,16 @@ as a fixed value and as a percentage of the host's total memory.
 Thresholds for `CRITICAL` and `WARNING` memory usage have usable defaults, but
 max memory usage is required before this plugin can be used. See the
 [configuration options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_hs2ds2vms.md
+++ b/docs/plugins/check_vmware_hs2ds2vms.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -60,6 +61,16 @@ also used by both hosts and datastores.
 
 If specifying a shared Custom Attribute or prefix, per-resource Custom
 Attribute flags are rejected (error condition).
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_question.md
+++ b/docs/plugins/check_vmware_question.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -34,6 +35,16 @@ This plugin monitors the `question` property of evaluated Virtual Machines.
 The status of this property indicates whether an interactive question is
 blocking the virtual machine's execution. While a Virtual Machine is in this
 state it is not available for normal use.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_rps_memory.md
+++ b/docs/plugins/check_vmware_rps_memory.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Limitations](#limitations)
 - [`Resources` Resource Pool](#resources-resource-pool)
 - [Performance Data](#performance-data)
@@ -40,6 +41,16 @@ is intended to help spot which VM is responsible for a state change alert.
 Thresholds for `CRITICAL` and `WARNING` memory usage have usable defaults, but
 max memory usage is required before this plugin can be used. See the
 [configuration options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Limitations
 

--- a/docs/plugins/check_vmware_snapshots_age.md
+++ b/docs/plugins/check_vmware_snapshots_age.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -41,6 +42,16 @@ issue.
 Thresholds for `CRITICAL` and `WARNING` age values have usable defaults, but
 may require adjustment for your environment. See the [configuration
 options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_snapshots_count.md
+++ b/docs/plugins/check_vmware_snapshots_count.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -46,6 +47,16 @@ issue.
 Thresholds for `CRITICAL` and `WARNING` count values have usable defaults, but
 may require adjustment for your environment. See the [configuration
 options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_snapshots_size.md
+++ b/docs/plugins/check_vmware_snapshots_size.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -45,6 +46,16 @@ issue.
 Thresholds for `CRITICAL` and `WARNING` age values have usable defaults, but
 may require adjustment for your environment. See the [configuration
 options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_tools.md
+++ b/docs/plugins/check_vmware_tools.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -29,6 +30,16 @@
 Nagios plugin used to monitor VMware Tools installations. See the
 [configuration options](#configuration-options) section for details regarding
 how the various Tools states are evaluated.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_vcpus.md
+++ b/docs/plugins/check_vmware_vcpus.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -31,6 +32,16 @@ Nagios plugin used to monitor allocation of virtual CPUs (vCPUs).
 Thresholds for `CRITICAL` and `WARNING` vCPUs allocation have usable defaults,
 but Max vCPUs allocation is required before this plugin can be used. See the
 [configuration options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_vhw.md
+++ b/docs/plugins/check_vmware_vhw.md
@@ -12,6 +12,7 @@
   - [Outdated-by or threshold range check](#outdated-by-or-threshold-range-check)
   - [Minimum required version check](#minimum-required-version-check)
   - [Default is minimum required version check](#default-is-minimum-required-version-check)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -85,6 +86,16 @@ considered a `CRITICAL` state.
 This mode requires that all hardware versions match or exceed the host or
 cluster default hardware version. This monitoring mode assumes that any
 deviation is considered a `WARNING` state.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 
@@ -179,8 +190,7 @@ the others.
 
 As of this writing, these monitoring modes are *not* implemented as
 subcommands, though this may change in the future based on feedback. See the
-[examples](#check_vmware_vhw-nagios-plugin) for this plugin for more
-information.
+[examples](#examples) for this plugin for more information.
 
 - Use the `-h` or `--help` flag to display current usage information.
 - Flags marked as **`required`** must be set via CLI flag.

--- a/docs/plugins/check_vmware_vm_backup_via_ca.md
+++ b/docs/plugins/check_vmware_vm_backup_via_ca.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
 - [Optional evaluation](#optional-evaluation)
 - [Installation](#installation)
@@ -29,6 +30,16 @@
 ## Overview
 
 Nagios plugin used to monitor the last backup date for virtual machines.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 

--- a/docs/plugins/check_vmware_vm_power_uptime.md
+++ b/docs/plugins/check_vmware_vm_power_uptime.md
@@ -8,6 +8,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
+- [Output](#output)
 - [Performance Data](#performance-data)
   - [Background](#background)
   - [Supported metrics](#supported-metrics)
@@ -41,6 +42,16 @@ In addition to reporting current power cycle uptime, this plugin also reports:
 Thresholds for `CRITICAL` and `WARNING` CPU usage have usable defaults, but
 may require adjustment for your environment. See the [configuration
 options](#configuration-options) section for details.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+
+See the [main project README](../../README.md) for details.
 
 ## Performance Data
 


### PR DESCRIPTION
Linting issues resolved:

- `MD051/link-fragments`
  - references to `Output` section invalid
- `MD053/link-image-reference-definitions`
  - links left behind after docs restructuring

fixes GH-700