### PR TITLE
Fix invalid object type in custom attributes msgs

### DIFF
--- a/internal/vsphere/attributes.go
+++ b/internal/vsphere/attributes.go
@@ -249,15 +249,17 @@ func GetObjectCustomAttribute(obj mo.ManagedEntity, customAttributeName string, 
 		case errors.Is(caValErr, ErrCustomAttributeNotSet):
 
 			logger.Printf(
-				"specified Custom Attribute %q not set on virtual machine %q",
+				"specified Custom Attribute %q not set on %s %q",
 				customAttributeName,
+				obj.Self.Type,
 				obj.Name,
 			)
 
 			if !ignoreMissingCA {
 				return CustomAttribute{}, fmt.Errorf(
-					"specified Custom Attribute %s not set on virtual machine %s: %w",
+					"specified Custom Attribute %q not set on %s %s: %w",
 					customAttributeName,
+					obj.Self.Type,
 					obj.Name,
 					ErrCustomAttributeNotSet,
 				)


### PR DESCRIPTION
- invalid fixed string in log message
- invalid fixed string in error message

This was likely missed when refactoring functionality specific
to a virtual machine so that it could be used for hosts, virtual
machines and datastores.

fixes GH-714