### PR TITLE
Adjust make all recipe job timeout

### DIFF
--- a/.github/workflows/lint-and-build-using-make.yml
+++ b/.github/workflows/lint-and-build-using-make.yml
@@ -57,7 +57,7 @@ jobs:
     name: Build codebase using Makefile all recipe
     runs-on: ubuntu-latest
     # Default: 360 minutes
-    timeout-minutes: 40
+    timeout-minutes: 55
     container:
       image: "ghcr.io/atc0005/go-ci:go-ci-stable-mirror-build"
 


### PR DESCRIPTION
Increase from 40 minutes to 55 minutes to handle recent timeouts.

The cause of the timeouts was assumed to be related to an upgrade of the Go toolchain from 1.17.13 to 1.19.1, but sufficient testing has not been performed to conclusively prove this is the case. This timeout adjustment is considered as a hotfix until additional testing can be performed.

fixes GH-724