### PR TITLE
Enable library logging at Trace level also

### DIFF
--- a/cmd/check_vmware_alarms/logging.go
+++ b/cmd/check_vmware_alarms/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_datastore_performance/logging.go
+++ b/cmd/check_vmware_datastore_performance/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_datastore_performance/main.go
+++ b/cmd/check_vmware_datastore_performance/main.go
@@ -37,10 +37,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -65,10 +61,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_datastore_space/logging.go
+++ b/cmd/check_vmware_datastore_space/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_disk_consolidation/logging.go
+++ b/cmd/check_vmware_disk_consolidation/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_host_cpu/logging.go
+++ b/cmd/check_vmware_host_cpu/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_host_memory/logging.go
+++ b/cmd/check_vmware_host_memory/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -37,10 +37,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -65,10 +61,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_hs2ds2vms/logging.go
+++ b/cmd/check_vmware_hs2ds2vms/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -37,10 +37,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -65,10 +61,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_question/logging.go
+++ b/cmd/check_vmware_question/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -35,9 +35,6 @@ func main() {
 		// troubleshooting.
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
@@ -63,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_rps_memory/logging.go
+++ b/cmd/check_vmware_rps_memory/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -37,10 +37,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -65,10 +61,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_snapshots_age/logging.go
+++ b/cmd/check_vmware_snapshots_age/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_snapshots_count/logging.go
+++ b/cmd/check_vmware_snapshots_count/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_snapshots_size/logging.go
+++ b/cmd/check_vmware_snapshots_size/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_tools/logging.go
+++ b/cmd/check_vmware_tools/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_vcpus/logging.go
+++ b/cmd/check_vmware_vcpus/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_vhw/logging.go
+++ b/cmd/check_vmware_vhw/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_vm_backup_via_ca/logging.go
+++ b/cmd/check_vmware_vm_backup_via_ca/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.

--- a/cmd/check_vmware_vm_power_uptime/logging.go
+++ b/cmd/check_vmware_vm_power_uptime/logging.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package main
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/atc0005/check-vmware/internal/vsphere"
+)
+
+func handleLibraryLogging() {
+	switch {
+	case zerolog.GlobalLevel() == zerolog.DebugLevel ||
+		zerolog.GlobalLevel() == zerolog.TraceLevel:
+
+		vsphere.EnableLogging()
+
+	default:
+
+		vsphere.DisableLogging()
+	}
+}

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -36,10 +36,6 @@ func main() {
 		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
 	}(plugin)
 
-	// Disable library debug logging output by default
-	// vsphere.EnableLogging()
-	vsphere.DisableLogging()
-
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific
 	// settings are applied.
@@ -64,10 +60,9 @@ func main() {
 		return
 	}
 
-	// Enable library-level logging if debug logging level is enabled app-wide
-	if cfg.LoggingLevel == config.LogLevelDebug {
-		vsphere.EnableLogging()
-	}
+	// Enable library-level logging if debug or greater logging level is
+	// enabled app-wide.
+	handleLibraryLogging()
 
 	// Set context deadline equal to user-specified timeout value for plugin
 	// runtime/execution.


### PR DESCRIPTION
In addition to enabling library logging at Debug level (existing behavior), enable library logging at Trace level also to match expectations of "debug" logging (Trace level is a more verbose logging level than Debug).

fixes GH-749