### PR TITLE
Refactor project build process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,3 +83,22 @@ updates:
           # Go release and no longer supported Go versions.
           - ">= 1.20"
           - "< 1.19"
+
+  # Monitor image used to build dev & stable project releases
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/builds"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "builds"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "docker"

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@
 # https://gist.github.com/subfuzion/0bd969d08fe0d8b5cc4b23c795854a13
 # https://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # https://stackoverflow.com/questions/38801796/makefile-set-if-variable-is-empty
+# https://stackoverflow.com/questions/1909188/define-make-variable-at-rule-execution-time
 
-SHELL = /bin/bash
+SHELL := /bin/bash
 
-# Space-separated list of cmd/BINARY_NAME directories to build
+# List of cmd/BINARY_NAME directories to build
 WHAT 					= check_vmware_tools \
 							check_vmware_vcpus \
 							check_vmware_vhw \
@@ -41,24 +42,73 @@ WHAT 					= check_vmware_tools \
 							check_vmware_alarms \
 							check_vmware_vm_backup_via_ca \
 
-PROJECT_NAME			= check-vmware
+PROJECT_NAME			:= check-vmware
 
 # What package holds the "version" variable used in branding/version output?
 # VERSION_VAR_PKG			= $(shell go list -m)
-VERSION_VAR_PKG			= $(shell go list -m)/internal/config
+VERSION_VAR_PKG			:= $(shell go list -m)/internal/config
 # VERSION_VAR_PKG			= main
 
-OUTPUTDIR 				= release_assets
+OUTPUTDIR 				:= release_assets
 
-ROOT_PATH				:= $(CURDIR)/$(OUTPUTDIR)
+ASSETS_PATH				:= $(CURDIR)/$(OUTPUTDIR)
+
+PROJECT_DIR				:= $(CURDIR)
 
 # https://gist.github.com/TheHippo/7e4d9ec4b7ed4c0d7a39839e6800cc16
-VERSION 				= $(shell git describe --always --long --dirty)
+# VERSION 				:= $(shell git describe --always --long --dirty)
 
-# Used when generating download URLs when building assets for public release
-RELEASE_TAG 			= $(shell git describe --exact-match --tags)
+# Use https://github.com/choffmeister/git-describe-semver to generate
+# semantic version compatible tag values for use as image suffix.
+#
+# Attempt to use environment variable. This is set within GitHub Actions
+# Workflows, but not via local Makefile use. If environment variable is not
+# set, attempt to use local installation of choffmeister/git-describe-semver
+# tool.
+#
+# The build image used by this project for release builds includes this tool,
+# so we are covered there.
+#
+# If this tool is not already installed locally and someone runs this Makefile
+# we use a "YOU_NEED_TO_*" placeholder string as a breadcrumb indicating what
+# needs to be done to resolve the issue.
+#
+# This is a VERY expensive operation as it is expanded on every use (due to
+# the ?= assignment operator)
+# REPO_VERSION              ?= $(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe)
+#
+ifeq ($(origin REPO_VERSION), undefined)
+# This is an expensive operation on systems where tools like Cisco AMP are
+# present/active.
+REPO_VERSION 				:= $(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe)
 
-BASE_URL				= https://github.com/atc0005/$(PROJECT_NAME)/releases/download
+# https://make.mad-scientist.net/deferred-simple-variable-expansion/
+# https://stackoverflow.com/questions/50771834/how-to-get-at-most-once-semantics-in-variable-assignments
+# REPO_VERSION = $(eval REPO_VERSION := $$(shell git-describe-semver --fallback 'v0.0.0' 2>/dev/null || echo YOU_NEED_TO_RUN_depsinstall_makefile_recipe))$(REPO_VERSION)
+
+endif
+
+DEB_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(REPO_VERSION)_amd64.deb
+RPM_X64_STABLE_PKG_FILE	:= $(PROJECT_NAME)-$(REPO_VERSION).x86_64.rpm
+
+DEB_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(REPO_VERSION)_amd64.deb
+RPM_X64_DEV_PKG_FILE	:= $(PROJECT_NAME)-dev-$(REPO_VERSION).x86_64.rpm
+
+# Used when generating download URLs when building assets for public release.
+# If the current commit doesn't match an existing tag an error is emitted. We
+# toss that error and use a placeholder value.
+RELEASE_TAG 			:= $(shell git describe --exact-match --tags 2>/dev/null || echo PLACEHOLDER)
+
+# TESTING purposes
+#RELEASE_TAG 			:= 0.11.0
+
+BASE_URL				:= https://github.com/atc0005/$(PROJECT_NAME)/releases/download
+
+ALL_DOWNLOAD_LINKS_FILE	:= $(ASSETS_PATH)/$(PROJECT_NAME)-$(RELEASE_TAG)-all-links.txt
+PKG_DOWNLOAD_LINKS_FILE	:= $(ASSETS_PATH)/$(PROJECT_NAME)-$(RELEASE_TAG)-pkgs-links.txt
+
+# Exported so that nFPM can reference it when generating packages.
+export SEMVER  := $(REPO_VERSION)
 
 # The default `go build` process embeds debugging information. Building
 # without that debugging information reduces the binary size by around 28%.
@@ -96,11 +146,12 @@ BASE_URL				= https://github.com/atc0005/$(PROJECT_NAME)/releases/download
 #	https://golang.org/cmd/cgo/
 #	explicitly disable use of cgo
 #	removes potential need for linkage against local c library (e.g., glibc)
-BUILDCMD				=	CGO_ENABLED=0 go build -mod=vendor -trimpath -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(VERSION)"
-QUICK_BUILDCMD			=	go build -mod=vendor
-GOCLEANCMD				=	go clean -mod=vendor ./...
-GITCLEANCMD				= 	git clean -xfd
-CHECKSUMCMD				=	sha256sum -b
+BUILDCMD				:=	CGO_ENABLED=0 go build -mod=vendor -trimpath -a -ldflags "-s -w -X $(VERSION_VAR_PKG).version=$(REPO_VERSION)"
+QUICK_BUILDCMD			:=	go build -mod=vendor
+GOCLEANCMD				:=	go clean -mod=vendor ./...
+GITCLEANCMD				:= 	git clean -xfd
+CHECKSUMCMD				:=	sha256sum -b
+COMPRESSCMD				:= xz --compress --threads=0
 
 .DEFAULT_GOAL := help
 
@@ -124,7 +175,7 @@ lintinstall:
 
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
-	@echo "Installing latest staticcheck version ..."
+	@echo "Installing latest stable staticcheck version via go install command ..."
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	staticcheck --version
 
@@ -165,15 +216,35 @@ goclean:
 	@echo "Removing object files and cached files ..."
 	@$(GOCLEANCMD)
 	@echo "Removing any existing release assets"
-	@mkdir -p "$(OUTPUTDIR)"
-	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-linux-*)
-	@rm -vf $(wildcard ${OUTPUTDIR}/*/*-windows-*)
-	@rm -vf $(wildcard ${OUTPUTDIR}/*-links.txt)
-	@find ${OUTPUTDIR} -mindepth 1 -type d -empty -delete
+	@mkdir -p "$(ASSETS_PATH)"
+	@rm -vf $(wildcard $(ASSETS_PATH)/*/*-linux-*)
+	@rm -vf $(wildcard $(ASSETS_PATH)/*/*-windows-*)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.rpm)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.rpm.sha256)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.deb)
+	@rm -vf $(wildcard $(ASSETS_PATH)/packages/*/*.deb.sha256)
+	@rm -vf $(wildcard $(ASSETS_PATH)/*-links.txt)
+	@rm -vf $(wildcard $(PROJECT_DIR)/cmd/*/*.syso)
+
+	@echo "Removing any existing quick build release assets"
+	@for target in $(WHAT); do \
+		rm -vf $(ASSETS_PATH)/$${target}/$${target}; \
+	done
+
+	@echo "Removing any empty asset build paths"
+	@find ${ASSETS_PATH} -mindepth 1 -type d -empty -delete
 
 .PHONY: clean
 ## clean: alias for goclean
 clean: goclean
+
+.PHONY: clean-linux-x64-dev
+## clean-linux-x64-dev: removes dev assets for Linux x64 distros
+clean-linux-x64-dev:
+	@echo "Removing dev build assets used to generate dev packages"
+	@for target in $(WHAT); do \
+		rm -vf $(ASSETS_PATH)/$${target}/$$target-linux-amd64-dev; \
+	done
 
 .PHONY: gitclean
 ## gitclean: WARNING - recursively cleans working tree by removing non-versioned files
@@ -185,17 +256,24 @@ gitclean:
 ## pristine: run goclean and gitclean to remove local changes
 pristine: goclean gitclean
 
-.PHONY: quick
-## quick: generates non-release binaries for current platform, arch
-quick:
-	@echo "Building non-release assets for current platform, arch ..."
+.PHONY: depsinstall
+## depsinstall: install or update common build dependencies
+depsinstall:
+	@echo "Installing current version of build dependencies"
 
-	@for target in $(WHAT); do \
-		echo "  Building $$target binary" && \
-		$(QUICK_BUILDCMD) ${PWD}/cmd/$$target; \
-	done
+	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
-	@echo "Completed tasks for quick build"
+	@echo "Installing latest go-winres version ..."
+	go install github.com/tc-hib/go-winres@latest
+
+	@echo "Installing latest nFPM version ..."
+	go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+	nfpm --version
+
+	@echo "Installing latest git-describe-semver version ..."
+	go install github.com/choffmeister/git-describe-semver@latest
+
+	@echo "Finished installing or updating build dependencies"
 
 .PHONY: all
 # https://stackoverflow.com/questions/3267145/makefile-execute-another-target
@@ -203,151 +281,576 @@ quick:
 all: clean windows linux
 	@echo "Completed all cross-platform builds ..."
 
-.PHONY: windows-x86
-## windows-x86: generates assets for Windows x86 systems
-windows-x86:
+.PHONY: quick
+## quick: generates non-release binaries for current platform, arch
+quick:
+	@echo "Building non-release assets for current platform, arch ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$${target} && \
+		echo "  building $${target} binary" && \
+		$(QUICK_BUILDCMD) -o $(ASSETS_PATH)/$${target}/$${target} $(PROJECT_DIR)/cmd/$${target}; \
+	done
+
+	@echo "Completed tasks for quick build"
+
+.PHONY: windows-x86-build
+## windows-x86-build: builds assets for Windows x86 systems
+windows-x86-build:
 	@echo "Building release assets for windows x86 ..."
 
-	@for target in $(WHAT); do \
-		mkdir -p $(ROOT_PATH)/$$target && \
-		echo "  Building $$target 386 binary" && \
-		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-windows-386.exe ${PWD}/cmd/$$target && \
-		echo "  Generating $$target checksum file" && \
-		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-windows-386.exe > $$target-$(VERSION)-windows-386.exe.sha256 && \
-		cd $$OLDPWD; \
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  running go generate for $$target 386 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=386 go generate && \
+		cd $(PROJECT_DIR) && \
+		echo "  building $$target 386 binary" && \
+		env GOOS=windows GOARCH=386 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-windows-386.exe $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for windows x86"
+
+.PHONY: windows-x86-compress
+## windows-x86-compress: compresses generated Windows x86 assets
+windows-x86-compress:
+	@echo "Compressing release assets for windows x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target 386 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-386.exe; \
+	done
+
+	@echo "Completed compress tasks for windows x86"
+
+.PHONY: windows-x86-checksums
+## windows-x86-checksums: generates checksum files for Windows x86 assets
+windows-x86-checksums:
+	@echo "Generating checksum files for windows x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-windows-386.exe.xz > $$target-windows-386.exe.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed generation of checksum files for windows x86"
 
 .PHONY: windows-x86-links
 ## windows-x86-links: generates download URLs for Windows x86 assets
 windows-x86-links:
 	@echo "Generating download links for windows x86 assets ..."
 
-	@for target in $(WHAT); do \
-		echo "  Generating $$target download links" && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-windows-386.exe" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-windows-386.exe.sha256" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt; \
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-386.exe.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-386.exe.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 	done
 
 	@echo "Completed generating download links for windows x86 assets"
 
-.PHONY: windows-x64
-## windows-x64: generates assets for Windows x64 systems
-windows-x64:
+.PHONY: windows-x64-build
+## windows-x64-build: builds assets for Windows x64 systems
+windows-x64-build:
 	@echo "Building release assets for windows x64 ..."
 
-	@for target in $(WHAT); do \
-		mkdir -p $(ROOT_PATH)/$$target && \
-		echo "  Building $$target amd64 binary" && \
-		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-windows-amd64.exe ${PWD}/cmd/$$target && \
-		echo "  Generating $$target checksum file" && \
-		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-windows-amd64.exe > $$target-$(VERSION)-windows-amd64.exe.sha256 && \
-		cd $$OLDPWD; \
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  running go generate for $$target amd64 binary ..." && \
+		cd $(PROJECT_DIR)/cmd/$$target && \
+		env GOOS=windows GOARCH=amd64 go generate && \
+		cd $(PROJECT_DIR) && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=windows GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for windows x64"
+
+.PHONY: windows-x64-compress
+## windows-x64-compress: compresses generated Windows x64 assets
+windows-x64-compress:
+	@echo "Compressing release assets for windows x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe; \
+	done
+
+	@echo "Completed compress tasks for windows x64"
+
+.PHONY: windows-x64-checksums
+## windows-x64-checksums: generates checksum files for Windows x64 assets
+windows-x64-checksums:
+	@echo "Generating checksum files for windows x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-windows-amd64.exe.xz > $$target-windows-amd64.exe.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed generation of checksum files for windows x64"
 
 .PHONY: windows-x64-links
 ## windows-x64-links: generates download URLs for Windows x64 assets
 windows-x64-links:
 	@echo "Generating download links for windows x64 assets ..."
 
-	@for target in $(WHAT); do \
-		echo "  Generating $$target download links" && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-windows-amd64.exe" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-windows-amd64.exe.sha256" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt; \
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-windows-amd64.exe.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 	done
 
 	@echo "Completed generating download links for windows x64 assets"
 
+.PHONY: windows-x86
+## windows-x86: generates assets for Windows x86
+windows-x86: windows-x86-build windows-x86-compress windows-x86-checksums
+	@echo "Completed all tasks for windows x86"
+
+.PHONY: windows-x64
+## windows-x64: generates assets for Windows x64
+windows-x64: windows-x64-build windows-x64-compress windows-x64-checksums
+	@echo "Completed all tasks for windows x64"
+
 .PHONY: windows
 ## windows: generates assets for Windows x86 and x64 systems
 windows: windows-x86 windows-x64
-	@echo "Completed all build tasks for windows"
+	@echo "Completed all tasks for windows"
 
 .PHONY: windows-links
 ## windows-links: generates download URLs for Windows x86 and x64 assets
 windows-links: windows-x86-links windows-x64-links
 	@echo "Completed generating download links for windows x86 and x64 assets"
 
-.PHONY: linux-x86
-## linux-x86: generates assets for Linux x86 distros
-linux-x86:
+.PHONY: linux-x86-build
+## linux-x86-build: builds assets for Linux x86 distros
+linux-x86-build:
 	@echo "Building release assets for linux x86 ..."
 
-	@for target in $(WHAT); do \
-		mkdir -p $(ROOT_PATH)/$$target && \
-		echo "  Building $$target 386 binary" && \
-		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-linux-386 ${PWD}/cmd/$$target && \
-		echo "  Generating $$target checksum file" && \
-		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-linux-386 > $$target-$(VERSION)-linux-386.sha256; \
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target 386 binary" && \
+		env GOOS=linux GOARCH=386 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-386 $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for linux x86"
+
+.PHONY: linux-x86-compress
+## linux-x86-compress: compresses generated Linux x86 assets
+linux-x86-compress:
+	@echo "Compressing release assets for linux x86 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target 386 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-386; \
+	done
+
+	@echo "Completed compress tasks for linux x86"
+
+.PHONY: linux-x86-checksums
+## linux-x86-checksums: generates checksum files for Linux x86 assets
+linux-x86-checksums:
+	@echo "Generating checksum files for linux x86 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-386.xz > $$target-linux-386.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+	@echo "Completed generation of checksum files for linux x86"
 
 .PHONY: linux-x86-links
 ## linux-x86-links: generates download URLs for Linux x86 assets
 linux-x86-links:
 	@echo "Generating download links for linux x86 assets ..."
 
-	@for target in $(WHAT); do \
-		echo "  Generating $$target download links" && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-linux-386" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-linux-386.sha256" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt; \
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-386.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-386.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 	done
 
 	@echo "Completed generating download links for linux x86 assets"
 
-.PHONY: linux-x64
-## linux-x64: generates assets for Linux x64 distros
-linux-x64:
+.PHONY: linux-x64-build
+## linux-x64-build: builds assets for Linux x64 distros
+linux-x64-build:
 	@echo "Building release assets for linux x64 ..."
 
-	@for target in $(WHAT); do \
-		mkdir -p $(ROOT_PATH)/$$target && \
-		echo "  Building $$target amd64 binary" && \
-		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ROOT_PATH)/$$target/$$target-$(VERSION)-linux-amd64 ${PWD}/cmd/$$target && \
-		echo "  Generating $$target checksum file" && \
-		cd $(ROOT_PATH)/$$target && \
-		$(CHECKSUMCMD) $$target-$(VERSION)-linux-amd64 > $$target-$(VERSION)-linux-amd64.sha256; \
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-amd64 $(PROJECT_DIR)/cmd/$$target; \
 	done
 
 	@echo "Completed build tasks for linux x64"
 
+.PHONY: linux-x64-compress
+## linux-x64-compress: compresses generated Linux x64 assets
+linux-x64-compress:
+	@echo "Compressing release assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64; \
+	done
+
+	@echo "Completed compress tasks for linux x64"
+
+.PHONY: linux-x64-checksums
+## linux-x64-checksums: generates checksum files for Linux x64 assets
+linux-x64-checksums:
+	@echo "Generating checksum files for linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-amd64.xz > $$target-linux-amd64.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
 .PHONY: linux-x64-links
-## linux-x64-links: generates download URLs for Linux x86 assets
+## linux-x64-links: generates download URLs for Linux x64 assets
 linux-x64-links:
 	@echo "Generating download links for linux x64 assets ..."
 
-	@for target in $(WHAT); do \
+	@set -e; for target in $(WHAT); do \
 		echo "  Generating $$target download links" && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-linux-amd64" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt && \
-		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-$(VERSION)-linux-amd64.sha256" >> $(ROOT_PATH)/$(PROJECT_NAME)-$(VERSION)-links.txt; \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
 	done
 
 	@echo "Completed generating download links for linux x64 assets"
 
+.PHONY: linux-x64-dev-build
+## linux-x64-dev-build: builds dev assets for Linux x64 distros
+linux-x64-dev-build:
+	@echo "Building dev assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		mkdir -p $(ASSETS_PATH)/$$target && \
+		echo "  building $$target amd64 binary" && \
+		env GOOS=linux GOARCH=amd64 $(BUILDCMD) -o $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev $(PROJECT_DIR)/cmd/$$target; \
+	done
+
+	@echo "Completed dev build tasks for linux x64"
+
+.PHONY: linux-x64-dev-compress
+## linux-x64-dev-compress: compresses generated dev Linux x64 assets
+linux-x64-dev-compress:
+	@echo "Compressing dev assets for linux x64 ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  compressing $$target amd64 binary" && \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev; \
+	done
+
+	@echo "Completed dev compress tasks for linux x64"
+
+.PHONY: linux-x64-dev-checksums
+## linux-x64-dev-checksums: generates checksum files for dev Linux x64 assets
+linux-x64-dev-checksums:
+	@echo "Generating checksum files for dev linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  generating $$target checksum file" && \
+		cd $(ASSETS_PATH)/$$target && \
+		$(CHECKSUMCMD) $$target-linux-amd64-dev.xz > $$target-linux-amd64-dev.xz.sha256 && \
+		cd $$OLDPWD; \
+	done
+
+.PHONY: linux-x64-dev-links
+## linux-x64-dev-links: generates download URLs for dev Linux x64 assets
+linux-x64-dev-links:
+	@echo "Generating download links for dev linux x64 assets ..."
+
+	@set -e; for target in $(WHAT); do \
+		echo "  Generating $$target download links" && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64-dev.xz" >> $(ALL_DOWNLOAD_LINKS_FILE) && \
+		echo "$(BASE_URL)/$(RELEASE_TAG)/$$target-linux-amd64-dev.xz.sha256" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+	done
+
+	@echo "Completed generating download links for dev linux x64 assets"
+
+.PHONY: linux-x86
+## linux-x86: generates assets for Linux x86
+linux-x86: linux-x86-build linux-x86-compress linux-x86-checksums
+	@echo "Completed all tasks for linux x86"
+
+.PHONY: linux-x64
+## linux-x64: generates assets for Linux x64
+linux-x64: linux-x64-build linux-x64-compress linux-x64-checksums
+	@echo "Completed all tasks for linux x64"
+
 .PHONY: linux
 ## linux: generates assets for Linux x86 and x64 distros
 linux: linux-x86 linux-x64
-	@echo "Completed all build tasks for linux"
+	@echo "Completed all tasks for linux"
 
 .PHONY: linux-links
 ## linux-links: generates download URLs for Linux x86 and x64 assets
 linux-links: linux-x86-links linux-x64-links
 	@echo "Completed generating download links for linux x86 and x64 assets"
 
+.PHONY: packages-stable
+## packages-stable: generates "stable" release series DEB and RPM packages
+packages-stable: linux-x64-build
+
+	@echo
+	@echo Generating stable release series packages ...
+
+	@mkdir -p $(ASSETS_PATH)/packages/stable
+
+	@echo
+	@echo "  - stable DEB package ..."
+	@cd $(PROJECT_DIR)/packages/stable && \
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/stable/$(DEB_X64_STABLE_PKG_FILE)
+
+	@echo
+	@echo "  - stable RPM package ..."
+	@cd $(PROJECT_DIR)/packages/stable && \
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/stable/$(RPM_X64_STABLE_PKG_FILE)
+
+	@echo
+	@echo "Generating checksum files ..."
+
+	@echo "  - stable DEB package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo "  - stable RPM package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo
+	@echo "Completed package build tasks"
+
+.PHONY: packages-dev
+## packages-dev: generates "dev" release series DEB and RPM packages
+packages-dev: linux-x64-dev-build
+
+	@echo
+	@echo Generating dev release series packages ...
+
+	@mkdir -p $(ASSETS_PATH)/packages/dev
+
+	@echo
+	@echo "  - dev DEB package ..."
+	@cd $(PROJECT_DIR)/packages/dev && \
+		nfpm package --config nfpm.yaml --packager deb --target $(ASSETS_PATH)/packages/dev/$(DEB_X64_DEV_PKG_FILE)
+
+	@echo
+	@echo "  - dev RPM package ..."
+	@cd $(PROJECT_DIR)/packages/dev && \
+		nfpm package --config nfpm.yaml --packager rpm --target $(ASSETS_PATH)/packages/dev/$(RPM_X64_DEV_PKG_FILE)
+
+	@echo
+	@echo "Generating checksum files ..."
+
+	@echo "  - dev DEB package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo "  - dev RPM package checksum file"
+	@set -e ;\
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			$(CHECKSUMCMD) $${file} > $${file}.sha256 ; \
+		done
+
+	@echo
+	@echo "Completed dev release package build tasks"
+
+.PHONY: packages
+## packages: generates "dev" and "stable" release series DEB and RPM packages
+packages: packages-dev packages-stable
+	@echo "Completed all package build tasks"
+
+.PHONY: package-links
+## package-links: generates download URLs for package assets
+package-links:
+
+	@echo "Generating download links for package assets ..."
+
+	@echo "  - DEB package download links"
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.deb.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.deb.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@echo "  - RPM package download links"
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+	@if [ -d $(ASSETS_PATH)/packages/dev ]; then \
+		cd $(ASSETS_PATH)/packages/dev && \
+		for file in $$(find . -name "*.rpm.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@if [ -d $(ASSETS_PATH)/packages/stable ]; then \
+		cd $(ASSETS_PATH)/packages/stable && \
+		for file in $$(find . -name "*.rpm.sha256" -printf '%P\n'); do \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(PKG_DOWNLOAD_LINKS_FILE) && \
+			echo "$(BASE_URL)/$(RELEASE_TAG)/$${file}" >> $(ALL_DOWNLOAD_LINKS_FILE); \
+		done; \
+	fi
+
+	@echo "Completed generating download links for package assets"
+
 .PHONY: links
-## links: generates download URLs for Windows and Linux x86 and x64 assets
-links: windows-x86-links windows-x64-links linux-x86-links linux-x64-links
+## links: generates download URLs for release assets
+links: windows-x86-links windows-x64-links linux-x86-links linux-x64-links package-links
 	@echo "Completed generating download links for all release assets"
 
-.PHONY: release-build
-## release-build: generates assets for public release
-release-build: clean linux-x64 linux-x64-links
+.PHONY: dev-build
+## dev-build: generates dev build assets for public release
+dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-compress linux-x64-dev-checksums linux-x64-dev-links
+	@echo "Completed all tasks for dev release build"
 
-	@echo "Completed all tasks for release build"
+.PHONY: release-build
+## release-build: generates stable build assets for public release
+release-build: clean packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums links
+	@echo "Completed all tasks for stable release build"
+
+.PHONY: helper-docker-builder-setup
+## helper-docker-builder-setup: refreshes builder image for Docker-based tasks
+helper-docker-builder-setup:
+
+	@echo "Beginning regeneration of Docker builder image"
+	@echo "Removing any previous build image"
+	@docker image prune --all --force --filter "label=atc0005_projects_builder_image"
+
+	@echo "Gathering Docker build environment details"
+	@docker version
+
+	@echo
+	@echo "Generating release builder image"
+	@docker image build \
+		--pull \
+		--no-cache \
+		--force-rm \
+		dependabot/docker/builds/ \
+		-t builder_image \
+		--label="atc0005_projects_builder_image"
+	@echo "Completed generation of release builder image"
+
+	@echo
+	@echo "Inspecting release builder image environment"
+	@docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" builder_image
+
+	@echo "Completed regeneration of Docker builder image"
+
+.PHONY: docker-release-build
+## docker-release-build: generates stable build assets for public release using Docker
+docker-release-build: clean helper-docker-builder-setup
+
+	@echo "Beginning release build using Docker"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	@docker container run \
+		--user $${UID:-1000} \
+		--rm \
+		-i \
+		-v $$PWD:$$PWD \
+		-w $$PWD \
+		builder_image \
+		env GOCACHE=/tmp/ make release-build
+
+	@echo "Completed release build using Docker"
+
+.PHONY: docker-dev-build
+## docker-dev-build: generates dev build assets for public release using Docker
+docker-dev-build: clean helper-docker-builder-setup
+
+	@echo "Beginning dev build using Docker"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	@docker container run \
+		--user $${UID:-1000} \
+		--rm \
+		-i \
+		-v $$PWD:$$PWD \
+		-w $$PWD \
+		builder_image \
+		env GOCACHE=/tmp/ make dev-build
+
+	@echo "Completed dev build using Docker"
+
+
+
+.PHONY: docker-packages
+## docker-packages: generates dev and stable packages using Docker
+docker-packages: helper-docker-builder-setup
+
+	@echo "Beginning package generation using Docker"
+
+	@echo
+	@echo "Using release builder image to generate packages"
+	@docker container run \
+		--user $${UID:-1000} \
+		--rm \
+		-i \
+		-v $$PWD:$$PWD \
+		-w $$PWD \
+		builder_image \
+		env GOCACHE=/tmp/ make packages
+
+	@echo "Completed package generation using Docker"

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ been tested.
 1. Review [configuration options](#configuration-options),
    [`examples`](#examples) and [`contrib`](#contrib) sections usage details.
 
+**NOTE**: Depending on which `Makefile` recipe you use the generated binary
+may be compressed and have an `xz` extension. If so, you should decompress the
+binary first before deploying it (e.g., `xz -d
+check_vmware_tools-linux-amd64.xz`).
+
 ### Using provided binaries
 
 #### Linux
@@ -266,8 +271,15 @@ been tested.
 1. Download plugins from the [Latest
    release](https://github.com/atc0005/check-vmware/releases/latest) that you
    are interested in
+1. Decompress binaries
+   - e.g., `xz -d check_vmware_tools-linux-amd64.xz`
 1. Review [configuration options](#configuration-options),
    [`examples`](#examples) and [`contrib`](#contrib) sections usage details.
+
+**NOTE**:
+
+DEB and RPM packages are provided as an alternative to manually deploying
+binaries.
 
 #### Windows
 

--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_alarms/winres/winres.json
+++ b/cmd/check_vmware_alarms/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor one or more datacenters for Triggered Alarms.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor one or more datacenters for Triggered Alarms.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_datastore_performance/main.go
+++ b/cmd/check_vmware_datastore_performance/main.go
@@ -23,6 +23,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_datastore_performance/winres/winres.json
+++ b/cmd/check_vmware_datastore_performance/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor datastore performance.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor datastore performance.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_datastore_space/winres/winres.json
+++ b/cmd/check_vmware_datastore_space/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor datastore usage.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor datastore usage.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_disk_consolidation/winres/winres.json
+++ b/cmd/check_vmware_disk_consolidation/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor Virtual Machine disk consolidation status.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor Virtual Machine disk consolidation status.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_host_cpu/winres/winres.json
+++ b/cmd/check_vmware_host_cpu/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor ESXi host CPU usage.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor ESXi host CPU usage.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -23,6 +23,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_host_memory/winres/winres.json
+++ b/cmd/check_vmware_host_memory/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor ESXi host memory.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor ESXi host memory.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -23,6 +23,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_hs2ds2vms/winres/winres.json
+++ b/cmd/check_vmware_hs2ds2vms/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor host/datastore/vm pairings.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor host/datastore/vm pairings.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_question/winres/winres.json
+++ b/cmd/check_vmware_question/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor whether a Virtual Machine is blocked from execution due to one or more Virtual Machines requiring an interactive response.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor whether a Virtual Machine is blocked from execution due to one or more Virtual Machines requiring an interactive response.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -23,6 +23,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_rps_memory/winres/winres.json
+++ b/cmd/check_vmware_rps_memory/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor memory usage across Resource Pools.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor memory usage across Resource Pools.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_snapshots_age/winres/winres.json
+++ b/cmd/check_vmware_snapshots_age/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor the age of Virtual Machine snapshots.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor the age of Virtual Machine snapshots.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_snapshots_count/winres/winres.json
+++ b/cmd/check_vmware_snapshots_count/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor the number of snapshots per Virtual Machine.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor the number of snapshots per Virtual Machine.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_snapshots_size/winres/winres.json
+++ b/cmd/check_vmware_snapshots_size/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor the cumulative size of snapshots for each Virtual Machine.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor the cumulative size of snapshots for each Virtual Machine.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_tools/winres/winres.json
+++ b/cmd/check_vmware_tools/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor VMware Tools installations.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor VMware Tools installations.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_vcpus/winres/winres.json
+++ b/cmd/check_vmware_vcpus/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor allocation of virtual CPUs (vCPUs).",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor allocation of virtual CPUs (vCPUs).",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_vhw/winres/winres.json
+++ b/cmd/check_vmware_vhw/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor virtual hardware versions.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor virtual hardware versions.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_vm_backup_via_ca/winres/winres.json
+++ b/cmd/check_vmware_vm_backup_via_ca/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor last backup date for VMs (via specified custom attribute).",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor last backup date for VMs (via specified custom attribute).",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -22,6 +22,8 @@ import (
 	zlog "github.com/rs/zerolog/log"
 )
 
+//go:generate go-winres make --product-version=git-tag --file-version=git-tag
+
 func main() {
 
 	plugin := nagios.NewPlugin()

--- a/cmd/check_vmware_vm_power_uptime/winres/winres.json
+++ b/cmd/check_vmware_vm_power_uptime/winres/winres.json
@@ -1,0 +1,53 @@
+{
+  "RT_MANIFEST": {
+    "#1": {
+      "0409": {
+        "identity": {
+          "name": "",
+          "version": ""
+        },
+        "description": "Nagios plugin used to monitor Virtual Machine (power cycle) uptime.",
+        "minimum-os": "win7",
+        "execution-level": "as invoker",
+        "ui-access": false,
+        "auto-elevate": false,
+        "dpi-awareness": "system",
+        "disable-theming": false,
+        "disable-window-filtering": false,
+        "high-resolution-scrolling-aware": false,
+        "ultra-high-resolution-scrolling-aware": false,
+        "long-path-aware": false,
+        "printer-driver-isolation": false,
+        "gdi-scaling": false,
+        "segment-heap": false,
+        "use-common-controls-v6": false
+      }
+    }
+  },
+  "RT_VERSION": {
+    "#1": {
+      "0000": {
+        "fixed": {
+          "file_version": "0.0.0.0",
+          "product_version": "0.0.0.0"
+        },
+        "info": {
+          "0409": {
+            "Comments": "Part of the atc0005/check-vmware project",
+            "CompanyName": "github.com/atc0005",
+            "FileDescription": "Nagios plugin used to monitor Virtual Machine (power cycle) uptime.",
+            "FileVersion": "",
+            "InternalName": "check_cert",
+            "LegalCopyright": "© Adam Chalkley. Licensed under MIT.",
+            "LegalTrademarks": "",
+            "OriginalFilename": "main.go",
+            "PrivateBuild": "",
+            "ProductName": "check-vmware",
+            "ProductVersion": "",
+            "SpecialBuild": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Purpose:
+#
+# Dependabot-maintained Dockerfile used by Makefile-driven release builds.
+#
+
+# https://github.com/atc0005/go-ci/releases
+# https://github.com/atc0005/go-ci/pkgs/container/go-ci
+FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.9.0

--- a/packages/dev/nfpm.yaml
+++ b/packages/dev/nfpm.yaml
@@ -1,0 +1,248 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# nfpm config file used for generating RPM and DEB packages.
+#
+# https://nfpm.goreleaser.com/usage/
+# https://nfpm.goreleaser.com/configuration/
+
+name: "check-vmware-dev"
+arch: "amd64"
+platform: "linux"
+
+# The SEMVER environment variable is set via the Makefile. Call `make
+# packages` to generate packages.
+version: ${SEMVER}
+
+section: "default"
+priority: "extra"
+maintainer: "Adam Chalkley <atc0005@users.noreply.github.com>"
+description: Go-based tooling to monitor VMware environments (dev build).
+vendor: "atc0005"
+homepage: "https://github.com/atc0005/check-vmware"
+license: "MIT"
+# changelog: "changelog.yaml"
+contents:
+  - src: ../../release_assets/check_vmware_tools/check_vmware_tools-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_tools_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_tools/check_vmware_tools-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_tools_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vcpus/check_vmware_vcpus-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_vcpus_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vcpus/check_vmware_vcpus-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_vcpus_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vhw/check_vmware_vhw-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_vhw_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vhw/check_vmware_vhw-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_vhw_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_hs2ds2vms/check_vmware_hs2ds2vms-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_hs2ds2vms_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_hs2ds2vms/check_vmware_hs2ds2vms-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_hs2ds2vms_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_datastore_space/check_vmware_datastore_space-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_datastore_space_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_datastore_space/check_vmware_datastore_space-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_datastore_space_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_datastore_performance/check_vmware_datastore_performance-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_datastore_performance_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_datastore_performance/check_vmware_datastore_performance-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_datastore_performance_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_age/check_vmware_snapshots_age-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_age_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_age/check_vmware_snapshots_age-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_age_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_count/check_vmware_snapshots_count-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_count_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_count/check_vmware_snapshots_count-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_count_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_size/check_vmware_snapshots_size-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_size_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_size/check_vmware_snapshots_size-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_size_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_rps_memory/check_vmware_rps_memory-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_rps_memory_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_rps_memory/check_vmware_rps_memory-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_rps_memory_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_host_memory/check_vmware_host_memory-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_host_memory_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_host_memory/check_vmware_host_memory-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_host_memory_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_host_cpu/check_vmware_host_cpu-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_host_cpu_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_host_cpu/check_vmware_host_cpu-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_host_cpu_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vm_power_uptime/check_vmware_vm_power_uptime-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_vm_power_uptime_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vm_power_uptime/check_vmware_vm_power_uptime-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_vm_power_uptime_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_disk_consolidation/check_vmware_disk_consolidation-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_disk_consolidation_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_disk_consolidation/check_vmware_disk_consolidation-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_disk_consolidation_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_question/check_vmware_question-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_question_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_question/check_vmware_question-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_question_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_alarms/check_vmware_alarms-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_alarms_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_alarms/check_vmware_alarms-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_alarms_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vm_backup_via_ca/check_vmware_vm_backup_via_ca-linux-amd64-dev
+    dst: /usr/lib64/nagios/plugins/check_vmware_vm_backup_via_ca_dev
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vm_backup_via_ca/check_vmware_vm_backup_via_ca-linux-amd64-dev
+    dst: /usr/lib/nagios/plugins/check_vmware_vm_backup_via_ca_dev
+    file_info:
+      mode: 0755
+    packager: deb
+
+overrides:
+  rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
+    scripts:
+      # preinstall: ./scripts/rpm/preinstall.sh
+      postinstall: ./scripts/rpm/postinstall.sh
+      # postremove: ./scripts/rpm/postremove.sh
+  deb:
+    scripts:
+      # preinstall: ./scripts/deb/preinstall.sh
+      postinstall: ./scripts/deb/postinstall.sh
+      # preremove: ./scripts/deb/preremove.sh

--- a/packages/dev/scripts/deb/postinstall.sh
+++ b/packages/dev/scripts/deb/postinstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-vmware"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name_suffix="_dev"
+plugin_path="/usr/lib/nagios/plugins"
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "#######################################################################"
+echo "NOTE:"
+echo
+echo "This is a dev build; binaries installed by this package have a _dev"
+echo "suffix to allow installation alongside stable versions."
+echo
+echo "Feedback for all releases is welcome, but especially so for dev builds."
+echo "Thank you in advance!"
+echo "#######################################################################"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo

--- a/packages/dev/scripts/rpm/postinstall.sh
+++ b/packages/dev/scripts/rpm/postinstall.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-vmware"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name_suffix="_dev"
+plugin_path="/usr/lib64/nagios/plugins"
+
+#
+# Set required SELinux context to allow plugin use when SELinux is enabled.
+#
+
+# Make sure we can locate the selinuxenabled binary.
+if [ -x "$(command -v selinuxenabled)" ]; then
+    selinuxenabled
+
+    if [ $? -ne 0 ]; then
+        echo -e "\n[--] SELinux is not enabled, skipping application of contexts."
+    else
+        # SELinux is enabled. Set context.
+        echo -e "\nApplying SELinux contexts on plugins ..."
+
+        for plugin_name in \
+            check_vmware_tools \
+            check_vmware_vcpus \
+            check_vmware_vhw \
+            check_vmware_hs2ds2vms \
+            check_vmware_datastore_space \
+            check_vmware_datastore_performance \
+            check_vmware_snapshots_age \
+            check_vmware_snapshots_count \
+            check_vmware_snapshots_size \
+            check_vmware_rps_memory \
+            check_vmware_host_memory \
+            check_vmware_host_cpu \
+            check_vmware_vm_power_uptime \
+            check_vmware_disk_consolidation \
+            check_vmware_question \
+            check_vmware_alarms \
+            check_vmware_vm_backup_via_ca
+        do
+
+            echo -e "\tApplying SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+
+            chcon \
+                --verbose \
+                -t nagios_unconfined_plugin_exec_t \
+                -u system_u \
+                -r object_r \
+                "${plugin_path}/${plugin_name}${plugin_name_suffix}"
+
+            if [ $? -eq 0 ]; then
+                echo -e "\t[OK] Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            else
+                echo -e "\t[!!] Failed to set SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            fi
+
+        done
+    fi
+
+else
+    echo "[!!] Error: Failed to locate selinuxenabled command." >&2
+fi
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "#######################################################################"
+echo "NOTE:"
+echo
+echo "This is a dev build; binaries installed by this package have a ${plugin_name_suffix}"
+echo "suffix to allow installation alongside stable versions."
+echo
+echo "Feedback for all releases is welcome, but especially so for dev builds."
+echo "Thank you in advance!"
+echo "#######################################################################"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo
+
+
+# Copying contexts from existing plugin:
+#
+# [root@atc0005-rhel8-test ~]# ls -laZ /usr/lib64/nagios/plugins/check_by_ssh
+# -rwxr-xr-x. root root system_u:object_r:nagios_unconfined_plugin_exec_t:s0 /usr/lib64/nagios/plugins/check_by_ssh
+# [root@atc0005-rhel8-test ~]# sudo chcon --verbose --reference /usr/lib64/nagios/plugins/check_by_ssh /usr/lib64/nagios/plugins/check_cert
+
+# Explicitly applying contexts:
+#
+# [root@atc0005-rhel8-test ~]# sudo chcon --verbose -t nagios_unconfined_plugin_exec_t -u system_u -r object_r /usr/lib64/nagios/plugins/check_cert
+# changing security context of '/usr/lib64/nagios/plugins/check_cert'
+#
+# [root@atc0005-rhel8-test ~]# ls -laZ /usr/lib64/nagios/plugins/check_cert
+# -rwxr-xr-x. 1 root root system_u:object_r:nagios_unconfined_plugin_exec_t:s0 6035136 Dec 12 11:14 /usr/lib64/nagios/plugins/check_cert

--- a/packages/stable/nfpm.yaml
+++ b/packages/stable/nfpm.yaml
@@ -1,0 +1,248 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# nfpm config file used for generating RPM and DEB packages.
+#
+# https://nfpm.goreleaser.com/usage/
+# https://nfpm.goreleaser.com/configuration/
+
+name: "check-vmware"
+arch: "amd64"
+platform: "linux"
+
+# The SEMVER environment variable is set via the Makefile. Call `make
+# packages` to generate packages.
+version: ${SEMVER}
+
+section: "default"
+priority: "extra"
+maintainer: "Adam Chalkley <atc0005@users.noreply.github.com>"
+description: Go-based tooling to monitor VMware environments.
+vendor: "atc0005"
+homepage: "https://github.com/atc0005/check-vmware"
+license: "MIT"
+# changelog: "changelog.yaml"
+contents:
+  - src: ../../release_assets/check_vmware_tools/check_vmware_tools-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_tools
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_tools/check_vmware_tools-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_tools
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vcpus/check_vmware_vcpus-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_vcpus
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vcpus/check_vmware_vcpus-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_vcpus
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vhw/check_vmware_vhw-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_vhw
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vhw/check_vmware_vhw-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_vhw
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_hs2ds2vms/check_vmware_hs2ds2vms-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_hs2ds2vms
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_hs2ds2vms/check_vmware_hs2ds2vms-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_hs2ds2vms
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_datastore_space/check_vmware_datastore_space-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_datastore_space
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_datastore_space/check_vmware_datastore_space-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_datastore_space
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_datastore_performance/check_vmware_datastore_performance-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_datastore_performance
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_datastore_performance/check_vmware_datastore_performance-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_datastore_performance
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_age/check_vmware_snapshots_age-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_age
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_age/check_vmware_snapshots_age-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_age
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_count/check_vmware_snapshots_count-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_count
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_count/check_vmware_snapshots_count-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_count
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_snapshots_size/check_vmware_snapshots_size-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_snapshots_size
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_snapshots_size/check_vmware_snapshots_size-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_snapshots_size
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_rps_memory/check_vmware_rps_memory-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_rps_memory
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_rps_memory/check_vmware_rps_memory-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_rps_memory
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_host_memory/check_vmware_host_memory-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_host_memory
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_host_memory/check_vmware_host_memory-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_host_memory
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_host_cpu/check_vmware_host_cpu-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_host_cpu
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_host_cpu/check_vmware_host_cpu-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_host_cpu
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vm_power_uptime/check_vmware_vm_power_uptime-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_vm_power_uptime
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vm_power_uptime/check_vmware_vm_power_uptime-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_vm_power_uptime
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_disk_consolidation/check_vmware_disk_consolidation-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_disk_consolidation
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_disk_consolidation/check_vmware_disk_consolidation-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_disk_consolidation
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_question/check_vmware_question-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_question
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_question/check_vmware_question-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_question
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_alarms/check_vmware_alarms-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_alarms
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_alarms/check_vmware_alarms-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_alarms
+    file_info:
+      mode: 0755
+    packager: deb
+
+  - src: ../../release_assets/check_vmware_vm_backup_via_ca/check_vmware_vm_backup_via_ca-linux-amd64
+    dst: /usr/lib64/nagios/plugins/check_vmware_vm_backup_via_ca
+    file_info:
+      mode: 0755
+    packager: rpm
+
+  - src: ../../release_assets/check_vmware_vm_backup_via_ca/check_vmware_vm_backup_via_ca-linux-amd64
+    dst: /usr/lib/nagios/plugins/check_vmware_vm_backup_via_ca
+    file_info:
+      mode: 0755
+    packager: deb
+
+overrides:
+  rpm:
+    depends:
+      # Provides selinuxenabled tool.
+      # Installed by default even via the "minimal" installation option.
+      - libselinux-utils
+    scripts:
+      # preinstall: ./scripts/rpm/preinstall.sh
+      postinstall: ./scripts/rpm/postinstall.sh
+      # postremove: ./scripts/rpm/postremove.sh
+  deb:
+    scripts:
+      # preinstall: ./scripts/deb/preinstall.sh
+      postinstall: ./scripts/deb/postinstall.sh
+      # preremove: ./scripts/deb/preremove.sh

--- a/packages/stable/scripts/deb/postinstall.sh
+++ b/packages/stable/scripts/deb/postinstall.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-vmware"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name_suffix=""
+plugin_path="/usr/lib/nagios/plugins"
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo

--- a/packages/stable/scripts/rpm/postinstall.sh
+++ b/packages/stable/scripts/rpm/postinstall.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+project_org="atc0005"
+project_shortname="check-vmware"
+
+project_fq_name="${project_org}/${project_shortname}"
+project_url_base="https://github.com/${project_org}"
+project_repo="${project_url_base}/${project_shortname}"
+project_releases="${project_repo}/releases"
+project_issues="${project_repo}/issues"
+project_discussions="${project_repo}/discussions"
+
+plugin_name_suffix=""
+plugin_path="/usr/lib64/nagios/plugins"
+
+#
+# Set required SELinux context to allow plugin use when SELinux is enabled.
+#
+
+# Make sure we can locate the selinuxenabled binary.
+if [ -x "$(command -v selinuxenabled)" ]; then
+    selinuxenabled
+
+    if [ $? -ne 0 ]; then
+        echo -e "\n[--] SELinux is not enabled, skipping application of contexts."
+    else
+        # SELinux is enabled. Set context.
+        echo -e "\nApplying SELinux contexts on plugins ..."
+
+        for plugin_name in \
+            check_vmware_tools \
+            check_vmware_vcpus \
+            check_vmware_vhw \
+            check_vmware_hs2ds2vms \
+            check_vmware_datastore_space \
+            check_vmware_datastore_performance \
+            check_vmware_snapshots_age \
+            check_vmware_snapshots_count \
+            check_vmware_snapshots_size \
+            check_vmware_rps_memory \
+            check_vmware_host_memory \
+            check_vmware_host_cpu \
+            check_vmware_vm_power_uptime \
+            check_vmware_disk_consolidation \
+            check_vmware_question \
+            check_vmware_alarms \
+            check_vmware_vm_backup_via_ca
+        do
+
+            echo -e "\tApplying SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+
+            chcon \
+                --verbose \
+                -t nagios_unconfined_plugin_exec_t \
+                -u system_u \
+                -r object_r \
+                "${plugin_path}/${plugin_name}${plugin_name_suffix}"
+
+            if [ $? -eq 0 ]; then
+                echo -e "\t[OK] Successfully applied SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            else
+                echo -e "\t[!!] Failed to set SELinux contexts on ${plugin_path}/${plugin_name}${plugin_name_suffix}"
+            fi
+
+        done
+    fi
+
+else
+    echo "[!!] Error: Failed to locate selinuxenabled command." >&2
+fi
+
+
+
+echo
+echo "Thank you for installing packages provided by the ${project_fq_name} project!"
+echo
+echo "Project resources:"
+echo
+echo "- Obtain latest release: ${project_releases}"
+echo "- View/Ask questions: ${project_discussions}"
+echo "- View/Open issues: ${project_issues}"
+echo
+
+
+# Copying contexts from existing plugin:
+#
+# [root@atc0005-rhel8-test ~]# ls -laZ /usr/lib64/nagios/plugins/check_by_ssh
+# -rwxr-xr-x. root root system_u:object_r:nagios_unconfined_plugin_exec_t:s0 /usr/lib64/nagios/plugins/check_by_ssh
+# [root@atc0005-rhel8-test ~]# sudo chcon --verbose --reference /usr/lib64/nagios/plugins/check_by_ssh /usr/lib64/nagios/plugins/check_cert
+
+# Explicitly applying contexts:
+#
+# [root@atc0005-rhel8-test ~]# sudo chcon --verbose -t nagios_unconfined_plugin_exec_t -u system_u -r object_r /usr/lib64/nagios/plugins/check_cert
+# changing security context of '/usr/lib64/nagios/plugins/check_cert'
+#
+# [root@atc0005-rhel8-test ~]# ls -laZ /usr/lib64/nagios/plugins/check_cert
+# -rwxr-xr-x. 1 root root system_u:object_r:nagios_unconfined_plugin_exec_t:s0 6035136 Dec 12 11:14 /usr/lib64/nagios/plugins/check_cert


### PR DESCRIPTION
## Changes

- Switch to semantic versioning (semver) compatible versioning pattern
  - filenames (where applicable)
  - embedded version metadata
- Generate RPM/DEB packages using nFPM
  - "stable" release packages
  - "dev" release packages
    - provides binaries with `_dev` suffix in order to more easily test the impact of new releases
- Add version metadata to Windows executables
  - Use `github.com/tc-hib/go-winres` and `winres.json` file to apply version details to Windows executables provided by this project
- Makefile: Compress binaries and use fixed filenames
  - static filenames (without version component)
  - compressed via `xz`
- Makefile: Refresh recipes to add "standard" set, new package-related options
- Build dev/stable releases using go-ci Docker image
- Add Dockerfile to provide "builder" image for Makefile-driven release builds
  - Update Dependabot configuration to add update monitoring for `go-ci-oldstable-build` image
  - Add Docker-based build recipes to Makefile
    - `docker-release-build`
    - `docker-dev-build` - `docker-packages`
- Update README
  - note decompression step needed after downloading individual
    binaries or building via some Makefile recipes
  - note DEB and RPM packages as alternatives to downloading
    individual binaries

## References

- fixes GH-770
- fixes GH-771
- fixes GH-772
- fixes GH-773
- fixes GH-774
- fixes GH-775