### PR TITLE
Fix '*-all-links.txt' generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,7 +765,7 @@ dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-co
 
 .PHONY: release-build
 ## release-build: generates stable build assets for public release
-release-build: clean packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums links
+release-build: clean packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums linux-x64-links package-links
 	@echo "Completed all tasks for stable release build"
 
 .PHONY: helper-docker-builder-setup


### PR DESCRIPTION
Drop use of `links` recipe which generates download link entries for *all* assets and instead list out which specific link entry groups we wish to include.

This prevents listing x86 and Windows assets for download which are not actually available.