### PR TITLE
Update .gitignore to exclude Windows syso files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 /check_vmware_question
 /check_vmware_alarms
 
+# Ignore go generate produced Windows executable resource files
+*.syso


### PR DESCRIPTION
These files are produced when running go generate
as part of the build process and should not be
retained in version control.

refs GH-772