### PR TITLE
Add rootless container builds via Docker/Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ QUICK_BUILDCMD			:=	go build -mod=vendor
 GOCLEANCMD				:=	go clean -mod=vendor ./...
 GITCLEANCMD				:= 	git clean -xfd
 CHECKSUMCMD				:=	sha256sum -b
-COMPRESSCMD				:= xz --compress --threads=0
+COMPRESSCMD				:= xz --compress --threads=0 --stdout
 
 .DEFAULT_GOAL := help
 
@@ -318,7 +318,9 @@ windows-x86-compress:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  compressing $$target 386 binary" && \
-		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-386.exe; \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-386.exe > \
+			$(ASSETS_PATH)/$$target/$$target-windows-386.exe.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-windows-386.exe; \
 	done
 
 	@echo "Completed compress tasks for windows x86"
@@ -374,7 +376,9 @@ windows-x64-compress:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  compressing $$target amd64 binary" && \
-		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe; \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe > \
+			$(ASSETS_PATH)/$$target/$$target-windows-amd64.exe.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-windows-amd64.exe; \
 	done
 
 	@echo "Completed compress tasks for windows x64"
@@ -446,7 +450,9 @@ linux-x86-compress:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  compressing $$target 386 binary" && \
-		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-386; \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-386 > \
+			$(ASSETS_PATH)/$$target/$$target-linux-386.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-386; \
 	done
 
 	@echo "Completed compress tasks for linux x86"
@@ -498,7 +504,9 @@ linux-x64-compress:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  compressing $$target amd64 binary" && \
-		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64; \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64 > \
+			$(ASSETS_PATH)/$$target/$$target-linux-amd64.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-amd64; \
 	done
 
 	@echo "Completed compress tasks for linux x64"
@@ -548,7 +556,9 @@ linux-x64-dev-compress:
 
 	@set -e; for target in $(WHAT); do \
 		echo "  compressing $$target amd64 binary" && \
-		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev; \
+		$(COMPRESSCMD) $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev > \
+			$(ASSETS_PATH)/$$target/$$target-linux-amd64-dev.xz && \
+		rm -f $(ASSETS_PATH)/$$target/$$target-linux-amd64-dev; \
 	done
 
 	@echo "Completed dev compress tasks for linux x64"
@@ -768,89 +778,157 @@ dev-build: clean linux-x64-dev-build packages-dev package-links linux-x64-dev-co
 release-build: clean packages-dev clean-linux-x64-dev packages-stable linux-x64-compress linux-x64-checksums linux-x64-links package-links
 	@echo "Completed all tasks for stable release build"
 
-.PHONY: helper-docker-builder-setup
-## helper-docker-builder-setup: refreshes builder image for Docker-based tasks
-helper-docker-builder-setup:
+.PHONY: helper-builder-setup
+helper-builder-setup:
 
-	@echo "Beginning regeneration of Docker builder image"
+	@echo "Beginning regeneration of builder image using $(CONTAINER_COMMAND)"
 	@echo "Removing any previous build image"
-	@docker image prune --all --force --filter "label=atc0005_projects_builder_image"
+	$(CONTAINER_COMMAND) image prune --all --force --filter "label=atc0005_projects_builder_image"
 
-	@echo "Gathering Docker build environment details"
-	@docker version
+	@echo "Gathering $(CONTAINER_COMMAND) build environment details"
+	@$(CONTAINER_COMMAND) version
 
 	@echo
 	@echo "Generating release builder image"
-	@docker image build \
+	$(CONTAINER_COMMAND) image build \
 		--pull \
 		--no-cache \
 		--force-rm \
-		dependabot/docker/builds/ \
+		. \
+		-f dependabot/docker/builds/Dockerfile \
 		-t builder_image \
 		--label="atc0005_projects_builder_image"
 	@echo "Completed generation of release builder image"
 
-	@echo
-	@echo "Inspecting release builder image environment"
-	@docker inspect --format "{{range .Config.Env}}{{println .}}{{end}}" builder_image
+	@echo "Listing current container images managed by $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) image ls
 
-	@echo "Completed regeneration of Docker builder image"
+	@echo
+	@echo "Inspecting release builder image environment using $(CONTAINER_COMMAND)"
+	@$(CONTAINER_COMMAND) inspect --format "{{range .Config.Env}}{{println .}}{{end}}" builder_image
+
+	@echo "Completed regeneration of builder image using $(CONTAINER_COMMAND)"
+
+	@echo "Prepare output path for generated assets"
+	@mkdir -p $(ASSETS_PATH)
 
 .PHONY: docker-release-build
-## docker-release-build: generates stable build assets for public release using Docker
-docker-release-build: clean helper-docker-builder-setup
+## docker-release-build: generates stable build assets for public release using docker container
+docker-release-build: CONTAINER_COMMAND := docker
+docker-release-build: clean helper-builder-setup
 
-	@echo "Beginning release build using Docker"
+	@echo "Beginning release build using $(CONTAINER_COMMAND)"
 
 	@echo
 	@echo "Using release builder image to generate project release assets"
-	@docker container run \
-		--user $${UID:-1000} \
+	$(CONTAINER_COMMAND) container run \
+		--user builduser:builduser \
 		--rm \
 		-i \
-		-v $$PWD:$$PWD \
-		-w $$PWD \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
 		builder_image \
-		env GOCACHE=/tmp/ make release-build
+		make release-build
 
-	@echo "Completed release build using Docker"
+	@echo "Completed release build using $(CONTAINER_COMMAND)"
+
+.PHONY: podman-release-build
+## podman-release-build: generates stable build assets for public release using podman container
+podman-release-build: CONTAINER_COMMAND := podman
+podman-release-build: clean helper-builder-setup
+
+	@echo "Beginning release build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make release-build
+
+	@echo "Completed release build using $(CONTAINER_COMMAND)"
 
 .PHONY: docker-dev-build
-## docker-dev-build: generates dev build assets for public release using Docker
-docker-dev-build: clean helper-docker-builder-setup
+## docker-dev-build: generates dev build assets for public release using docker container
+docker-dev-build: CONTAINER_COMMAND := docker
+docker-dev-build: clean helper-builder-setup
 
-	@echo "Beginning dev build using Docker"
+	@echo "Beginning dev build using $(CONTAINER_COMMAND)"
 
 	@echo
 	@echo "Using release builder image to generate project release assets"
-	@docker container run \
-		--user $${UID:-1000} \
+	$(CONTAINER_COMMAND) container run \
+		--user builduser:builduser \
 		--rm \
 		-i \
-		-v $$PWD:$$PWD \
-		-w $$PWD \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
 		builder_image \
-		env GOCACHE=/tmp/ make dev-build
+		make dev-build
 
-	@echo "Completed dev build using Docker"
+	@echo "Completed dev build using $(CONTAINER_COMMAND)"
 
+.PHONY: podman-dev-build
+## podman-dev-build: generates dev build assets for public release using podman container
+podman-dev-build: CONTAINER_COMMAND := podman
+podman-dev-build: clean helper-builder-setup
 
+	@echo "Beginning dev build using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate project release assets"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make dev-build
+
+	@echo "Completed dev build using $(CONTAINER_COMMAND)"
 
 .PHONY: docker-packages
-## docker-packages: generates dev and stable packages using Docker
-docker-packages: helper-docker-builder-setup
+## docker-packages: generates dev and stable packages using builder image
+docker-packages: CONTAINER_COMMAND := docker
+docker-packages: helper-builder-setup
 
-	@echo "Beginning package generation using Docker"
+	@echo "Beginning package generation using $(CONTAINER_COMMAND)"
 
 	@echo
 	@echo "Using release builder image to generate packages"
-	@docker container run \
-		--user $${UID:-1000} \
+
+	@echo "Building with $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) container run \
+		--rm \
+		--user builduser:builduser \
+		-i \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
+		builder_image \
+		make packages
+
+	@echo "Completed package generation using $(CONTAINER_COMMAND)"
+
+.PHONY: podman-packages
+## podman-packages: generates dev and stable packages using podman container
+podman-packages: CONTAINER_COMMAND := podman
+podman-packages: helper-builder-setup
+
+	@echo "Beginning package generation using $(CONTAINER_COMMAND)"
+
+	@echo
+	@echo "Using release builder image to generate packages"
+
+	@echo "Building with $(CONTAINER_COMMAND)"
+	$(CONTAINER_COMMAND) container run \
 		--rm \
 		-i \
-		-v $$PWD:$$PWD \
-		-w $$PWD \
+		-v $$PWD/$(OUTPUTDIR):/builds/$(OUTPUTDIR):rw \
+		-w /builds \
 		builder_image \
-		env GOCACHE=/tmp/ make packages
+		make packages
 
-	@echo "Completed package generation using Docker"
+	@echo "Completed package generation using $(CONTAINER_COMMAND)"

--- a/dependabot/docker/builds/Dockerfile
+++ b/dependabot/docker/builds/Dockerfile
@@ -14,3 +14,26 @@
 # https://github.com/atc0005/go-ci/releases
 # https://github.com/atc0005/go-ci/pkgs/container/go-ci
 FROM ghcr.io/atc0005/go-ci:go-ci-oldstable-build-v0.10.3
+
+# Setup isolated build environment with a full copy of the Git repo contents
+# MINUS any file or path listed in the .dockerignore file at the root of this
+# repo.
+RUN useradd --create-home --shell /bin/bash --user-group builduser
+
+# Prevent Git from complaining when it encounters Git-tracked directories that
+# are owned by someone other than the current user. We set this at the
+# "system" level so that the setting is not specific to any one user account.
+#
+# https://stackoverflow.com/questions/71849415/i-cannot-add-the-parent-directory-to-safe-directory-in-git
+# https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory
+# https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
+RUN git config --system --add safe.directory '*'
+
+# We skip setting a specific container user. This allows generating a
+# container with a bind-mounted path using Podman and explicitly specifying
+# `--user builduser:builduser` using Docker.
+#
+#USER builduser
+
+WORKDIR /builds
+COPY --chown=builduser:builduser . /builds


### PR DESCRIPTION
- update builder image Dockerfile
  - copy project/repo content into container at build time - explicitly changing owner:group to `builduser`
  - explicitly create new `builduser` user and group
    - this is explicitly used for Docker-based builds
  - set `/builds` as the working directory
  - add new `.dockerignore` file to exclude the same items as the `.gitignore` file
  - set Git `safe.directory` logic at system level
- update Makefile recipes
  - add separate docker/podman variants of container-based project build recipes - each uses slightly different logic to achieve rootless container execution
  - explicitly emit the tool used to perform specific tasks
    - this can be useful to help explain why a generated builder image does not appear in the `docker image ls` output as a sysadmin might expect (if it was instead built with the `docker` command)
  - rename/remove the helper build recipe from the `help` recipe output (not useful to call directly)
  - to explicitly run the build container as the `builduser` user that is created during build image generation when using Docker to build/run containers (Podman uses different settings)
  - to send `xz` compressed output to stdout, then redirect to a target file
    - this works around failures to `chmod` and `chgrp` the compressed copy of input files when run within a non-root container
  - to explicitly bind mount the `release_assets` path into `/builds/release_assets` (using the same Makefile variable) read/write (instead of relying on implied read/write access)
  - to explicitly use `/builds` as the working directory

This collection of changes allows reliably building this project using either Docker or Podman via a "rootless" container.