### PR TITLE
Add .dockerignore file for use during image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Copyright 2023 Adam Chalkley
+#
+# https://github.com/atc0005/check-vmware
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Ignore Visual Studio Code workspace-level settings
+/.vscode
+
+# Ignore local "scratch" directory of temporary files
+scratch/
+
+# Generated assets are placed here
+/release_assets
+
+# Ignore one-off CLI app builds
+/check_vmware_*
+
+# Ignore go generate produced Windows executable resource files
+*.syso


### PR DESCRIPTION
This was intended to be included along with the recent rootless container builds work.

refs GH-793