### PR TITLE
Update vuln analysis GHAW to remove on.push hook

### DIFF
--- a/.github/workflows/project-analysis.yml
+++ b/.github/workflows/project-analysis.yml
@@ -8,9 +8,6 @@
 name: Project Analysis
 
 on:
-  push:
-  # branches: [master]
-
   pull_request:
     # `synchronized` seems to equate to pushing new commits to a linked branch
     # (whether force-pushed or not)


### PR DESCRIPTION
This hook was previously needed for proper operation of the `Vulnerability / CodeQL` job so that it could compare before/after changes against the base branch.

This requirement was removed as part of recent work in the github/codeql-action project.

I'm keeping the event type check for jobs already using it for the time being.

refs atc0005/todo#60