### PR TITLE
Update error annotation implementation

### DIFF
--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_datastore_performance/main.go
+++ b/cmd/check_vmware_datastore_performance/main.go
@@ -32,12 +32,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -32,12 +32,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -32,12 +32,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -32,12 +32,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -31,12 +31,9 @@ func main() {
 	// defer this from the start so it is the last deferred function to run
 	defer plugin.ReturnCheckResults()
 
-	// Collect last minute details just before ending plugin execution.
-	defer func(plugin *nagios.Plugin) {
-		// Annotate errors (if applicable) with additional context to aid in
-		// troubleshooting.
-		plugin.Errors = vsphere.AnnotateError(plugin.Errors...)
-	}(plugin)
+	// Annotate all errors (if any) with remediation advice just before ending
+	// plugin execution.
+	defer vsphere.AnnotateError(plugin)
 
 	// Setup configuration by parsing user-provided flags. Note plugin type so
 	// that only applicable CLI flags are exposed and any plugin-specific


### PR DESCRIPTION
Switch from entirely local error annotation implementation to use of upstream implementation as our "base". Project specific error advice is included alongside the default errors advice map provided by the upstream implementation.