### PR TITLE
Use UNKNOWN state for perfdata add failure

### DIFF
--- a/cmd/check_vmware_alarms/main.go
+++ b/cmd/check_vmware_alarms/main.go
@@ -280,6 +280,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("datacenters", len(dcs)).
@@ -349,12 +366,6 @@ func main() {
 			dcsEvalNames,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		return
 
 	default:
@@ -378,12 +389,6 @@ func main() {
 			cfg.DatacenterNames,
 			dcsEvalNames,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		return
 

--- a/cmd/check_vmware_datastore_performance/main.go
+++ b/cmd/check_vmware_datastore_performance/main.go
@@ -357,6 +357,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Collect performance data metrics for each percentile in the active
 	// interval.
 	percentiles := activePerfSummaryIdx.Percentiles()
@@ -435,12 +452,6 @@ func main() {
 			cfg.HideHistoricalDatastorePerfMetricSets,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 
 		return
@@ -461,12 +472,6 @@ func main() {
 			dsPerfSummarySet,
 			cfg.HideHistoricalDatastorePerfMetricSets,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
@@ -489,12 +494,6 @@ func main() {
 			cfg.HideHistoricalDatastorePerfMetricSets,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -513,12 +512,6 @@ func main() {
 			dsPerfSummarySet,
 			cfg.HideHistoricalDatastorePerfMetricSets,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_datastore_space/main.go
+++ b/cmd/check_vmware_datastore_space/main.go
@@ -253,6 +253,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Str("datastore_name", datastore.Name).
@@ -286,12 +303,6 @@ func main() {
 			dsSpaceUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -312,12 +323,6 @@ func main() {
 			dsSpaceUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -335,12 +340,6 @@ func main() {
 			c.Client,
 			dsSpaceUsage,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_disk_consolidation/main.go
+++ b/cmd/check_vmware_disk_consolidation/main.go
@@ -301,6 +301,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -342,12 +359,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -375,12 +386,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -262,6 +262,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Str("host_name", hostSystem.Name).
@@ -295,12 +312,6 @@ func main() {
 			hsUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -323,12 +334,6 @@ func main() {
 			hsUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -348,12 +353,6 @@ func main() {
 			hsVMs,
 			hsUsage,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -263,6 +263,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Str("host_name", hostSystem.Name).
@@ -294,12 +311,6 @@ func main() {
 			hsUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -322,12 +333,6 @@ func main() {
 			hsUsage,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -347,12 +352,6 @@ func main() {
 			hsVMs,
 			hsUsage,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -444,6 +444,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -499,12 +516,6 @@ func main() {
 			cfg.HostCAName(),
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -539,12 +550,6 @@ func main() {
 			cfg.DatastoreCAName(),
 			cfg.HostCAName(),
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_question/main.go
+++ b/cmd/check_vmware_question/main.go
@@ -265,6 +265,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -307,12 +324,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -340,12 +351,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_rps_memory/main.go
+++ b/cmd/check_vmware_rps_memory/main.go
@@ -362,6 +362,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -403,12 +420,6 @@ func main() {
 			vms,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -437,12 +448,6 @@ func main() {
 			vms,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -468,12 +473,6 @@ func main() {
 			resourcePools,
 			vms,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_snapshots_age/main.go
+++ b/cmd/check_vmware_snapshots_age/main.go
@@ -302,6 +302,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -344,12 +361,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -381,12 +392,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -414,12 +419,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_snapshots_count/main.go
+++ b/cmd/check_vmware_snapshots_count/main.go
@@ -302,6 +302,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -348,12 +365,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -389,12 +400,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -422,12 +427,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_snapshots_size/main.go
+++ b/cmd/check_vmware_snapshots_size/main.go
@@ -302,6 +302,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -348,12 +365,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -389,12 +400,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -420,12 +425,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_tools/main.go
+++ b/cmd/check_vmware_tools/main.go
@@ -266,6 +266,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -308,12 +325,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = serviceState.ExitCode
 
 		return
@@ -346,12 +357,6 @@ func main() {
 		cfg.ExcludedResourcePools,
 		resourcePools,
 	)
-
-	if err := plugin.AddPerfData(false, pd...); err != nil {
-		log.Error().
-			Err(err).
-			Msg("failed to add performance data")
-	}
 
 	plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -297,6 +297,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -338,12 +355,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -375,12 +386,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -409,12 +414,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_vhw/main.go
+++ b/cmd/check_vmware_vhw/main.go
@@ -294,6 +294,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -350,12 +367,6 @@ func main() {
 				resourcePools,
 			)
 
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
-
 			plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 			return
@@ -386,12 +397,6 @@ func main() {
 				cfg.ExcludedResourcePools,
 				resourcePools,
 			)
-
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
 
 			plugin.ExitStatusCode = nagios.StateOKExitCode
 
@@ -443,12 +448,6 @@ func main() {
 				resourcePools,
 			)
 
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
-
 			plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 			return
@@ -477,12 +476,6 @@ func main() {
 				cfg.ExcludedResourcePools,
 				resourcePools,
 			)
-
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
 
 			plugin.ExitStatusCode = nagios.StateOKExitCode
 
@@ -534,12 +527,6 @@ func main() {
 				resourcePools,
 			)
 
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
-
 			plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 			return
@@ -568,12 +555,6 @@ func main() {
 				cfg.ExcludedResourcePools,
 				resourcePools,
 			)
-
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
 
 			plugin.ExitStatusCode = nagios.StateOKExitCode
 
@@ -630,12 +611,6 @@ func main() {
 				resourcePools,
 			)
 
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
-
 			plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 			return
@@ -668,12 +643,6 @@ func main() {
 				resourcePools,
 			)
 
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
-
 			plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 			return
@@ -703,12 +672,6 @@ func main() {
 				cfg.ExcludedResourcePools,
 				resourcePools,
 			)
-
-			if err := plugin.AddPerfData(false, pd...); err != nil {
-				log.Error().
-					Err(err).
-					Msg("failed to add performance data")
-			}
 
 			plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_vm_backup_via_ca/main.go
+++ b/cmd/check_vmware_vm_backup_via_ca/main.go
@@ -303,6 +303,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -363,12 +380,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = stateExitCode
 
 	default:
@@ -394,12 +405,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 

--- a/cmd/check_vmware_vm_power_uptime/main.go
+++ b/cmd/check_vmware_vm_power_uptime/main.go
@@ -255,6 +255,23 @@ func main() {
 		},
 	}
 
+	if err := plugin.AddPerfData(false, pd...); err != nil {
+		log.Error().
+			Err(err).
+			Msg("failed to add performance data")
+
+		// Surface the error in plugin output.
+		plugin.AddError(err)
+
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+		plugin.ServiceOutput = fmt.Sprintf(
+			"%s: Failed to process performance data metrics",
+			nagios.StateUNKNOWNLabel,
+		)
+
+		return
+	}
+
 	// Update logger with new performance data related fields
 	log = log.With().
 		Int("vms_total", len(vms)).
@@ -294,12 +311,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
 
 		return
@@ -331,12 +342,6 @@ func main() {
 			resourcePools,
 		)
 
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
-
 		plugin.ExitStatusCode = nagios.StateWARNINGExitCode
 
 		return
@@ -365,12 +370,6 @@ func main() {
 			cfg.ExcludedResourcePools,
 			resourcePools,
 		)
-
-		if err := plugin.AddPerfData(false, pd...); err != nil {
-			log.Error().
-				Err(err).
-				Msg("failed to add performance data")
-		}
 
 		plugin.ExitStatusCode = nagios.StateOKExitCode
 


### PR DESCRIPTION
- abort with UNKNOWN state when failing to add/gather generated performance data
- remove duplicate perfdata add step(s)
  - both the problem & OK state switch case blocks attempted to add perfdata metrics. Instead of updating the additional case blocks to use an UNKNOWN exit state we just move the step outside of the switch statements so the step is performed just once

refs atc0005/check-vmware#767
refs atc0005/todo#53