### PR TITLE
Replace fixed MO type strings with constants

### DIFF
--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -32,11 +32,14 @@ const CustomAttributeValNotSet string = "NotSet"
 
 // Managed Object Reference types
 const (
+	MgObjRefTypeAlarm           string = "Alarm"
 	MgObjRefTypeFolder          string = "Folder"
 	MgObjRefTypeDatacenter      string = "Datacenter"
+	MgObjRefTypeDatastore       string = "Datastore"
 	MgObjRefTypeComputeResource string = "ComputeResource"
 	MgObjRefTypeResourcePool    string = "ResourcePool"
 	MgObjRefTypeHostSystem      string = "HostSystem"
+	MgObjRefTypeNetwork         string = "Network"
 	MgObjRefTypeVirtualMachine  string = "VirtualMachine"
 	MgObjRefTypeVirtualApp      string = "VirtualApp"
 )

--- a/internal/vsphere/datacenters.go
+++ b/internal/vsphere/datacenters.go
@@ -51,9 +51,7 @@ func ValidateDCs(ctx context.Context, c *vim25.Client, datacenters []string) err
 	v, createViewErr := m.CreateContainerView(
 		ctx,
 		c.ServiceContent.RootFolder,
-		[]string{
-			"Datacenter",
-		},
+		[]string{MgObjRefTypeDatacenter},
 		true,
 	)
 	if createViewErr != nil {
@@ -75,7 +73,7 @@ func ValidateDCs(ctx context.Context, c *vim25.Client, datacenters []string) err
 	// Retrieve only the name property for all Datacenters.
 	props := []string{"name"}
 	var dcsSearchResults []mo.Datacenter
-	err := v.Retrieve(ctx, []string{"Datacenter"}, props, &dcsSearchResults)
+	err := v.Retrieve(ctx, []string{MgObjRefTypeDatacenter}, props, &dcsSearchResults)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to retrieve Datacenter properties: %w",

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -172,7 +172,7 @@ func getObjects(
 			objCount = len(*u)
 		}()
 
-		objKind = "Datacenter"
+		objKind = MgObjRefTypeDatacenter
 
 		if propsSubset {
 			props = getDatacenterPropsSubset()
@@ -183,7 +183,7 @@ func getObjects(
 			objCount = len(*u)
 		}()
 
-		objKind = "Alarm"
+		objKind = MgObjRefTypeAlarm
 
 		if propsSubset {
 			props = getAlarmPropsSubset()
@@ -194,7 +194,7 @@ func getObjects(
 			objCount = len(*u)
 		}()
 
-		objKind = "Datastore"
+		objKind = MgObjRefTypeDatastore
 
 		if propsSubset {
 			props = getDatastorePropsSubset()
@@ -204,7 +204,7 @@ func getObjects(
 		defer func() {
 			objCount = len(*u)
 		}()
-		objKind = "HostSystem"
+		objKind = MgObjRefTypeHostSystem
 
 		if propsSubset {
 			props = getHostSystemPropsSubset()
@@ -214,7 +214,7 @@ func getObjects(
 		defer func() {
 			objCount = len(*u)
 		}()
-		objKind = "VirtualMachine"
+		objKind = MgObjRefTypeVirtualMachine
 
 		if propsSubset {
 			props = getVirtualMachinePropsSubset()
@@ -224,7 +224,7 @@ func getObjects(
 		defer func() {
 			objCount = len(*u)
 		}()
-		objKind = "Network"
+		objKind = MgObjRefTypeNetwork
 
 		if propsSubset {
 			props = getNetworkPropsSubset()
@@ -234,7 +234,7 @@ func getObjects(
 		defer func() {
 			objCount = len(*u)
 		}()
-		objKind = "ResourcePool"
+		objKind = MgObjRefTypeResourcePool
 
 		if propsSubset {
 			props = getResourcePoolPropsSubset()
@@ -244,7 +244,7 @@ func getObjects(
 		defer func() {
 			objCount = len(*u)
 		}()
-		objKind = "VirtualApp"
+		objKind = MgObjRefTypeVirtualApp
 
 		if propsSubset {
 			props = getVirtualAppPropsSubset()
@@ -330,7 +330,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 	switch u := dst.(type) {
 	case *mo.Datastore:
 
-		objKind = "Datastore"
+		objKind = MgObjRefTypeDatastore
 		if propsSubset {
 			props = getDatastorePropsSubset()
 		}
@@ -353,7 +353,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 
 	case *mo.HostSystem:
 
-		objKind = "HostSystem"
+		objKind = MgObjRefTypeHostSystem
 		if propsSubset {
 			props = getHostSystemPropsSubset()
 		}
@@ -376,7 +376,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 
 	case *mo.VirtualMachine:
 
-		objKind = "VirtualMachine"
+		objKind = MgObjRefTypeVirtualMachine
 		if propsSubset {
 			props = getVirtualMachinePropsSubset()
 		}
@@ -399,7 +399,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 
 	case *mo.Network:
 
-		objKind = "Network"
+		objKind = MgObjRefTypeNetwork
 		if propsSubset {
 			props = getNetworkPropsSubset()
 		}
@@ -422,7 +422,7 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 
 	case *mo.ResourcePool:
 
-		objKind = "ResourcePool"
+		objKind = MgObjRefTypeResourcePool
 		if propsSubset {
 			props = getResourcePoolPropsSubset()
 		}

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -96,9 +96,7 @@ func ValidateRPs(ctx context.Context, c *vim25.Client, includeRPs []string, excl
 	v, createViewErr := m.CreateContainerView(
 		ctx,
 		c.ServiceContent.RootFolder,
-		[]string{
-			"ResourcePool",
-		},
+		[]string{MgObjRefTypeResourcePool},
 		true,
 	)
 	if createViewErr != nil {
@@ -120,7 +118,7 @@ func ValidateRPs(ctx context.Context, c *vim25.Client, includeRPs []string, excl
 	// Retrieve name property for all resource pools.
 	props := []string{"name"}
 	var rpsSearchResults []mo.ResourcePool
-	retrieveErr := v.Retrieve(ctx, []string{"ResourcePool"}, props, &rpsSearchResults)
+	retrieveErr := v.Retrieve(ctx, []string{MgObjRefTypeResourcePool}, props, &rpsSearchResults)
 	if retrieveErr != nil {
 		return fmt.Errorf(
 			"failed to retrieve ResourcePool properties: %w",


### PR DESCRIPTION
Replace use of fixed Managed Object type strings (e.g., "VirtualMachine") with constants (e.g., MgObjRefTypeVirtualMachine).