### PR TITLE
Finish supported metrics tables in plugin docs

### DIFF
--- a/docs/plugins/check_vmware_alarms.md
+++ b/docs/plugins/check_vmware_alarms.md
@@ -89,15 +89,21 @@ any feedback that you may have. Thanks in advance!
 
 ### Supported metrics
 
-- `time`
-- `datacenters`
-- `triggered_alarms`
-- `triggered_alarms_included`
-- `triggered_alarms_excluded`
-- `triggered_alarms_critical`
-- `triggered_alarms_warning`
-- `triggered_alarms_unknown`
-- `triggered_alarms_ok`
+**NOTE**: These metrics are based on the visibility of the service account
+used to login to the target VMware environment. If the service account cannot
+see a resource, it cannot evaluate the resource.
+
+| Metric                      | Unit of Measurement | Description                                                                       |
+| --------------------------- | ------------------- | --------------------------------------------------------------------------------- |
+| `time`                      | milliseconds        | plugin runtime                                                                    |
+| `datacenters`               |                     | all (visible) datacenters in the inventory                                        |
+| `triggered_alarms`          |                     | all (visible) triggered alarms for specified datacenters                          |
+| `triggered_alarms_included` |                     | triggered alarms remaining after they have been implicitly or explicitly excluded |
+| `triggered_alarms_excluded` |                     | triggered alarms that have been implicitly or explicitly excluded                 |
+| `triggered_alarms_critical` |                     | triggered alarms in the collection are considered to be in a CRITICAL state       |
+| `triggered_alarms_warning`  |                     | triggered alarms in the collection are considered to be in a WARNING state        |
+| `triggered_alarms_unknown`  |                     | triggered alarms in the collection are considered to be in an UNKNOWN state       |
+| `triggered_alarms_ok`       |                     | triggered alarms in the collection are considered to be in an OK state            |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_datastore_performance.md
+++ b/docs/plugins/check_vmware_datastore_performance.md
@@ -8,13 +8,13 @@
 ## Table of Contents
 
 - [Overview](#overview)
-  - [Requirements](#requirements)
-  - [How datastore performance metrics are evaluated](#how-datastore-performance-metrics-are-evaluated)
-  - [Performance Data metrics](#performance-data-metrics)
-  - [Stability of this plugin](#stability-of-this-plugin)
 - [Output](#output)
+  - [Requirements](#requirements)
+- [Stability of this plugin](#stability-of-this-plugin)
 - [Performance Data](#performance-data)
   - [Background](#background)
+  - [How datastore performance metrics are evaluated](#how-datastore-performance-metrics-are-evaluated)
+  - [Omitted metrics](#omitted-metrics)
   - [Supported metrics](#supported-metrics)
 - [Optional evaluation](#optional-evaluation)
 - [Installation](#installation)
@@ -38,6 +38,14 @@ details][vsphere-storage-performance-summary-data-object], this plugin also
 reports which VMs reside on the datastore along with their percentage of the
 total datastore space used. This is intended to help pinpoint potential causes
 of high latency at a glance.
+
+## Output
+
+The output for these plugins is designed to provide the one-line summary
+needed by Nagios for quick identification of a problem while providing longer,
+more detailed information for display within the web UI, use in email and
+Teams notifications
+([atc0005/send2teams](https://github.com/atc0005/send2teams)).
 
 ### Requirements
 
@@ -67,6 +75,47 @@ Available settings For `Storage I/O Control`:
 - `Disabled`
 - `Statistics enabled but Storage I/O disabled`
 - `Statistics and Storage I/O enabled`
+
+## Stability of this plugin
+
+**NOTE**: This plugin uses the [`QueryDatastorePerformanceSummary()` method
+provided by the `StorageResourceManager` Managed
+Object][vsphere-query-datastore-performance-summary-method]. While available
+since vSphere API 5.1, this API is marked as experimental (and subject to
+change/removal):
+
+> This is an experimental interface that is not intended for use in production
+> code.
+
+In addition to using the experimental `QueryDatastorePerformanceSummary()`
+API, this plugin uses the deprecated `statsCollectionEnabled` property from
+the [`StorageIORMInfo` Data
+Object][vsphere-storage-io-resource-management-data-object] to determine
+whether `Statistics Collection` is enabled for a datastore. Using the
+prescribed `enabled` property for [that Data
+Object][vsphere-storage-io-resource-management-data-object] to determine
+`Statistics Collection` does not work.
+
+If you use this plugin, please provide feedback by [opening a new discussion
+thread](https://github.com/atc0005/check-vmware/discussions/new).
+
+## Performance Data
+
+### Background
+
+Initial support has been added for emitting Performance Data / Metrics, but
+refinement suggestions are welcome.
+
+Consult the list below for the metrics implemented thus far, [the original
+discussion thread](https://github.com/atc0005/check-vmware/discussions/315)
+and the [Add Performance Data / Metrics
+support](https://github.com/atc0005/check-vmware/projects/1) project board for
+an index of the initial implementation work.
+
+Please add to an existing
+[Discussion](https://github.com/atc0005/check-vmware/discussions) thread or
+[open a new one](https://github.com/atc0005/check-vmware/discussions/new) with
+any feedback that you may have. Thanks in advance!
 
 ### How datastore performance metrics are evaluated
 
@@ -107,7 +156,7 @@ threshold flags is incompatible with specifying one or more percentile sets.
 By specifying multiple percentile sets, you are indicating that crossing the
 thresholds of any one set is enough to trigger a state change.
 
-### Performance Data metrics
+### Omitted metrics
 
 This plugin emits Nagios performance data metrics for each percentile in the
 active interval that is not completely of value `0`. Any percentile with all
@@ -115,77 +164,30 @@ active interval that is not completely of value `0`. Any percentile with all
 by the plugin.
 
 Please provide feedback by [opening a new
-issue](https://github.com/atc0005/check-vmware/issues/new) or commenting on
-the original discussion thread [here
-(GH-316)](https://github.com/atc0005/check-vmware/discussions/316) if you find
-that this decision causes problems with gathering metrics.
-
-### Stability of this plugin
-
-**NOTE**: This plugin uses the [`QueryDatastorePerformanceSummary()` method
-provided by the `StorageResourceManager` Managed
-Object][vsphere-query-datastore-performance-summary-method]. While available
-since vSphere API 5.1, this API is marked as experimental (and subject to
-change/removal):
-
-> This is an experimental interface that is not intended for use in production
-> code.
-
-In addition to using the experimental `QueryDatastorePerformanceSummary()`
-API, this plugin uses the deprecated `statsCollectionEnabled` property from
-the [`StorageIORMInfo` Data
-Object][vsphere-storage-io-resource-management-data-object] to determine
-whether `Statistics Collection` is enabled for a datastore. Using the
-prescribed `enabled` property for [that Data
-Object][vsphere-storage-io-resource-management-data-object] to determine
-`Statistics Collection` does not work.
-
-If you use this plugin, please provide feedback by [opening a new discussion
-thread](https://github.com/atc0005/check-vmware/discussions/new) or commenting
-on the original discussion thread [here
-(GH-316)](https://github.com/atc0005/check-vmware/discussions/316).
-
-## Output
-
-The output for these plugins is designed to provide the one-line summary
-needed by Nagios for quick identification of a problem while providing longer,
-more detailed information for display within the web UI, use in email and
-Teams notifications
-([atc0005/send2teams](https://github.com/atc0005/send2teams)).
+issue](https://github.com/atc0005/check-vmware/issues/new) if you find that
+this decision causes problems with gathering metrics.
 
 See the [main project README](../../README.md) for details.
 
-## Performance Data
-
-### Background
-
-Initial support has been added for emitting Performance Data / Metrics, but
-refinement suggestions are welcome.
-
-Consult the list below for the metrics implemented thus far, [the original
-discussion thread](https://github.com/atc0005/check-vmware/discussions/315)
-and the [Add Performance Data / Metrics
-support](https://github.com/atc0005/check-vmware/projects/1) project board for
-an index of the initial implementation work.
-
-Please add to an existing
-[Discussion](https://github.com/atc0005/check-vmware/discussions) thread or
-[open a new one](https://github.com/atc0005/check-vmware/discussions/new) with
-any feedback that you may have. Thanks in advance!
-
 ### Supported metrics
 
-- `time`
-- `p*_read_latency`
-- `p*_write_latency`
-- `p*_vm_latency`
-- `p*_read_iops`
-- `p*_write_iops`
-- `vms`
-- `vms_powered_off`
-- `vms_powered_on`
+**NOTE**: These metrics are based on the visibility of the service account
+used to login to the target VMware environment. If the service account cannot
+see a resource, it cannot evaluate the resource.
 
-`*` is a placeholder for `90`, `80`, `70`, `60` & `50` percentiles.
+| Metric             | Unit of Measurement | Description                                                                     |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------- |
+| `time`             | milliseconds        | plugin runtime                                                                  |
+| `vms`              |                     | all (visible) virtual machines in the inventory                                 |
+| `vms_powered_on`   |                     | virtual machines powered on                                                     |
+| `vms_powered_off`  |                     | virtual machines powered off                                                    |
+| `p*_read_latency`  | milliseconds        | aggregated datastore latency for read operations                                |
+| `p*_write_latency` | milliseconds        | aggregated datastore latency for write operations                               |
+| `p*_vm_latency`    | milliseconds        | aggregated datastore latency as observed by VirtualMachines using the datastore |
+| `p*_read_iops`     | reads per second    | aggregated datastore read I/O rate                                              |
+| `p*_read_iops`     | writes per second   | aggregated datastore write I/O rate                                             |
+
+**NOTE**: `*` is a placeholder for `90`, `80`, `70`, `60` & `50` percentiles.
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_datastore_space.md
+++ b/docs/plugins/check_vmware_datastore_space.md
@@ -63,13 +63,19 @@ any feedback that you may have. Thanks in advance!
 
 ### Supported metrics
 
-- `time`
-- `datastore_space_usage`
-- `datastore_space_used`
-- `datastore_space_remaining`
-- `vms`
-- `vms_powered_off`
-- `vms_powered_on`
+**NOTE**: These metrics are based on the visibility of the service account
+used to login to the target VMware environment. If the service account cannot
+see a resource, it cannot evaluate the resource.
+
+| Metric                      | Unit of Measurement | Description                                     |
+| --------------------------- | ------------------- | ----------------------------------------------- |
+| `time`                      | milliseconds        | plugin runtime                                  |
+| `vms`                       |                     | all (visible) virtual machines in the datastore |
+| `vms_powered_on`            |                     | virtual machines powered on                     |
+| `vms_powered_off`           |                     | virtual machines powered off                    |
+| `datastore_space_usage`     | percentage          | datastore usage                                 |
+| `datastore_space_used`      | bytes               | datastore spaced used                           |
+| `datastore_space_remaining` | bytes               | datastore space remaining                       |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_disk_consolidation.md
+++ b/docs/plugins/check_vmware_disk_consolidation.md
@@ -112,29 +112,29 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                           | Alias of              | Description                                                                              |
-| -------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                           |                       | plugin runtime                                                                           |
-| `vms`                            | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                        | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                  | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`            | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                 |                       | virtual machines powered on                                                              |
-| `vms_powered_off`                |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`           |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`         |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`    |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool`  |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                    |                       | all folders in the inventory                                                             |
-| `folders_excluded`               |                       | folders excluded by request                                                              |
-| `folders_included`               |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`              |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`             |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`        |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`        |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`       |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_consolidation_need`    |                       | virtual machines requiring disk consolidation                                            |
-| `vms_without_consolidation_need` |                       | virtual machines not requiring disk consolidation                                        |
+| Metric                           | Alias of              | Unit of Measurement | Description                                                                              |
+| -------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                           |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                            | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                        | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                  | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`            | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                 |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`                |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`           |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`         |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`    |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool`  |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                    |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`               |                       |                     | folders excluded by request                                                              |
+| `folders_included`               |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`              |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`             |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`        |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`        |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`       |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_consolidation_need`    |                       |                     | virtual machines requiring disk consolidation                                            |
+| `vms_without_consolidation_need` |                       |                     | virtual machines not requiring disk consolidation                                        |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_host_cpu.md
+++ b/docs/plugins/check_vmware_host_cpu.md
@@ -67,14 +67,20 @@ any feedback that you may have. Thanks in advance!
 
 ### Supported metrics
 
-- `time`
-- `cpu_usage`
-- `cpu_total`
-- `cpu_used`
-- `cpu_remaining`
-- `vms`
-- `vms_powered_off`
-- `vms_powered_on`
+**NOTE**: These metrics are based on the visibility of the service account
+used to login to the target VMware environment. If the service account cannot
+see a resource, it cannot evaluate the resource.
+
+| Metric            | Unit of Measurement | Description                                       |
+| ----------------- | ------------------- | ------------------------------------------------- |
+| `time`            | milliseconds        | plugin runtime                                    |
+| `vms`             |                     | all (visible) virtual machines on the host        |
+| `vms_powered_on`  |                     | virtual machines powered on                       |
+| `vms_powered_off` |                     | virtual machines powered off                      |
+| `cpu_usage`       | percentage          | cpu usage                                         |
+| `cpu_total`       | Hz                  | the total amount of CPU capacity for the host     |
+| `cpu_used`        | Hz                  | the amount of CPU used by the host                |
+| `cpu_remaining`   | Hz                  | the amount of CPU capacity remaining for the host |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_host_memory.md
+++ b/docs/plugins/check_vmware_host_memory.md
@@ -67,14 +67,20 @@ any feedback that you may have. Thanks in advance!
 
 ### Supported metrics
 
-- `time`
-- `memory_usage`
-- `memory_total`
-- `memory_used`
-- `memory_remaining`
-- `vms`
-- `vms_powered_off`
-- `vms_powered_on`
+**NOTE**: These metrics are based on the visibility of the service account
+used to login to the target VMware environment. If the service account cannot
+see a resource, it cannot evaluate the resource.
+
+| Metric             | Unit of Measurement | Description                                   |
+| ------------------ | ------------------- | --------------------------------------------- |
+| `time`             | milliseconds        | plugin runtime                                |
+| `vms`              |                     | all (visible) virtual machines on the host    |
+| `vms_powered_on`   |                     | virtual machines powered on                   |
+| `vms_powered_off`  |                     | virtual machines powered off                  |
+| `memory_usage`     | percentage          | cpu usage                                     |
+| `memory_total`     | Hz                  | the total amount of CPU capacity for the host |
+| `memory_used`      | Hz                  | the consumed host memory                      |
+| `memory_remaining` | Hz                  | the remaining host memory                     |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_hs2ds2vms.md
+++ b/docs/plugins/check_vmware_hs2ds2vms.md
@@ -112,30 +112,30 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                                        |
-| ------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                                     |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                                    |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                                    |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations               |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations               |
-| `vms_powered_on`                |                       | virtual machines powered on                                                                        |
-| `vms_powered_off`               |                       | virtual machines powered off                                                                       |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                               |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                                      |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default)           |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                              |
-| `folders_all`                   |                       | all folders in the inventory                                                                       |
-| `folders_excluded`              |                       | folders excluded by request                                                                        |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                                      |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                             |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                                |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                                 |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)                        |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied                      |
-| `pairing_issues`                |                       | virtual machines residing on a non-matched host/datastore (determined via given custom attributes) |
-| `datastores`                    |                       | all datastores in the inventory                                                                    |
-| `hosts`                         |                       | all hosts in the inventory                                                                         |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                                        |
+| ------------------------------- | --------------------- | ------------------- | -------------------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                                     |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                                    |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                                    |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations               |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations               |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                                        |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                                       |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                               |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                                      |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default)           |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                              |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                                       |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                                        |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                                      |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                             |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                                |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                                 |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)                        |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied                      |
+| `pairing_issues`                |                       |                     | virtual machines residing on a non-matched host/datastore (determined via given custom attributes) |
+| `datastores`                    |                       |                     | all datastores in the inventory                                                                    |
+| `hosts`                         |                       |                     | all hosts in the inventory                                                                         |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_question.md
+++ b/docs/plugins/check_vmware_question.md
@@ -86,29 +86,29 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_requiring_input`           |                       | virtual machines requiring sysadmin input (e.g., to continue the booting process)        |
-| `vms_not_requiring_input`       |                       | virtual machines not requiring sysadmin input (e.g., to continue the booting process)    |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_requiring_input`           |                       |                     | virtual machines requiring sysadmin input (e.g., to continue the booting process)        |
+| `vms_not_requiring_input`       |                       |                     | virtual machines not requiring sysadmin input (e.g., to continue the booting process)    |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_snapshots_age.md
+++ b/docs/plugins/check_vmware_snapshots_age.md
@@ -94,32 +94,32 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_critical_snapshots`   |                       | virtual machines with snapshots which have exceeded the given CRITICAL age threshold     |
-| `vms_with_warning_snapshots`    |                       | virtual machines with snapshots which have exceeded the given WARNING age threshold      |
-| `snapshots`                     |                       | total number of snapshots for virtual machines in the inventory                          |
-| `critical_snapshots`            |                       | virtual machine snapshots which have exceeded the given CRITICAL age threshold           |
-| `warning_snapshots`             |                       | virtual machine snapshots which have exceeded the given WARNING age threshold            |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_critical_snapshots`   |                       |                     | virtual machines with snapshots which have exceeded the given CRITICAL age threshold     |
+| `vms_with_warning_snapshots`    |                       |                     | virtual machines with snapshots which have exceeded the given WARNING age threshold      |
+| `snapshots`                     |                       |                     | total number of snapshots for virtual machines in the inventory                          |
+| `critical_snapshots`            |                       |                     | virtual machine snapshots which have exceeded the given CRITICAL age threshold           |
+| `warning_snapshots`             |                       |                     | virtual machine snapshots which have exceeded the given WARNING age threshold            |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_snapshots_count.md
+++ b/docs/plugins/check_vmware_snapshots_count.md
@@ -126,12 +126,6 @@ see a resource, it cannot evaluate the resource.
 | `critical_snapshots`            |                       | total number of snapshots which have exceeded the given CRITICAL threshold for snapshots per virtual machine |
 | `warning_snapshots`             |                       | total number of snapshots which have exceeded the given WARNING threshold for snapshots per virtual machine  |
 
-- `vms_with_critical_snapshots`
-- `vms_with_warning_snapshots`
-- `snapshots`
-- `critical_snapshots`
-- `warning_snapshots`
-
 ## Optional evaluation
 
 Some plugins provide optional support to limit evaluation of VMs to specific

--- a/docs/plugins/check_vmware_snapshots_size.md
+++ b/docs/plugins/check_vmware_snapshots_size.md
@@ -98,32 +98,32 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_critical_snapshots`   |                       | virtual machines with snapshots which have exceeded the given CRITICAL size threshold    |
-| `vms_with_warning_snapshots`    |                       | virtual machines with snapshots which have exceeded the given WARNING size threshold     |
-| `snapshots`                     |                       | total number of snapshots for virtual machines in the inventory                          |
-| `critical_snapshots`            |                       | virtual machine snapshots which have exceeded the given CRITICAL size threshold          |
-| `warning_snapshots`             |                       | virtual machine snapshots which have exceeded the given WARNING size threshold           |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_critical_snapshots`   |                       |                     | virtual machines with snapshots which have exceeded the given CRITICAL size threshold    |
+| `vms_with_warning_snapshots`    |                       |                     | virtual machines with snapshots which have exceeded the given WARNING size threshold     |
+| `snapshots`                     |                       |                     | total number of snapshots for virtual machines in the inventory                          |
+| `critical_snapshots`            |                       |                     | virtual machine snapshots which have exceeded the given CRITICAL size threshold          |
+| `warning_snapshots`             |                       |                     | virtual machine snapshots which have exceeded the given WARNING size threshold           |
 
 ## Installation
 

--- a/docs/plugins/check_vmware_tools.md
+++ b/docs/plugins/check_vmware_tools.md
@@ -81,29 +81,29 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_tools_issues`         |                       | virtual machines with detected VMware Tools issues                                       |
-| `vms_without_tools_issues`      |                       | virtual machines without detected VMware Tools issues                                    |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_tools_issues`         |                       |                     | virtual machines with detected VMware Tools issues                                       |
+| `vms_without_tools_issues`      |                       |                     | virtual machines without detected VMware Tools issues                                    |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_vcpus.md
+++ b/docs/plugins/check_vmware_vcpus.md
@@ -85,7 +85,7 @@ see a resource, it cannot evaluate the resource.
 
 | Metric                          | Alias of              | Unit of Measurement | Description                                                                                                  |
 | ------------------------------- | --------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `time`                          |                       |                     | plugin runtime                                                                                               |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                                               |
 | `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                                              |
 | `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                                              |
 | `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations                         |

--- a/docs/plugins/check_vmware_vhw.md
+++ b/docs/plugins/check_vmware_vhw.md
@@ -137,31 +137,31 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `hardware_versions_unique`      |                       | virtual machines with unique virtual machine hardware versions                           |
-| `hardware_versions_newest`      |                       | virtual machines with the newest virtual machine hardware version                        |
-| `hardware_versions_default`     |                       | virtual machines with the default cluster hardware version                               |
-| `hardware_versions_oldest`      |                       | virtual machines with the oldest hardware version                                        |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `hardware_versions_unique`      |                       |                     | virtual machines with unique virtual machine hardware versions                           |
+| `hardware_versions_newest`      |                       |                     | virtual machines with the newest virtual machine hardware version                        |
+| `hardware_versions_default`     |                       |                     | virtual machines with the default cluster hardware version                               |
+| `hardware_versions_oldest`      |                       |                     | virtual machines with the oldest hardware version                                        |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_vm_backup_via_ca.md
+++ b/docs/plugins/check_vmware_vm_backup_via_ca.md
@@ -65,29 +65,29 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_backup_dates`         |                       | virtual machines which have a recorded backup via user specified Custom Attribute        |
-| `vms_without_backup_dates`      |                       | virtual machines which do not have a recorded backup via user specified Custom Attribute |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_backup_dates`         |                       |                     | virtual machines which have a recorded backup via user specified Custom Attribute        |
+| `vms_without_backup_dates`      |                       |                     | virtual machines which do not have a recorded backup via user specified Custom Attribute |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_vm_list.md
+++ b/docs/plugins/check_vmware_vm_list.md
@@ -82,27 +82,27 @@ power state filtering.
 used to login to the target VMware environment. If the service account cannot
 see a resource, it cannot evaluate the resource.
 
-| Metric                          | Alias of              | Description                                                                              |
-| ------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                          |                       | plugin runtime                                                                           |
-| `vms`                           | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                       | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                 | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`           | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                |                       | virtual machines powered on                                                              |
-| `vms_powered_off`               |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`          |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`        |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`   |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool` |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                   |                       | all folders in the inventory                                                             |
-| `folders_excluded`              |                       | folders excluded by request                                                              |
-| `folders_included`              |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`             |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`            |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`       |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`       |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`      |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| Metric                          | Alias of              | Unit of Measurement | Description                                                                              |
+| ------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                          |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                           | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                       | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                 | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`           | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`               |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`          |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`        |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`   |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool` |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                   |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`              |                       |                     | folders excluded by request                                                              |
+| `folders_included`              |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`             |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`            |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`       |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`       |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`      |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
 
 ## Optional evaluation
 

--- a/docs/plugins/check_vmware_vm_power_uptime.md
+++ b/docs/plugins/check_vmware_vm_power_uptime.md
@@ -93,29 +93,29 @@ power state filtering.
 used to login to the target VMware environment. If the service account can't
 see a resource, it cannot evaluate the resource.
 
-| Metric                           | Alias of              | Description                                                                              |
-| -------------------------------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `time`                           |                       | plugin runtime                                                                           |
-| `vms`                            | `vms_all`             | all (visible) virtual machines in the inventory                                          |
-| `vms_all`                        | `vms`                 | all (visible) virtual machines in the inventory                                          |
-| `vms_evaluated`                  | `vms_after_filtering` | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_after_filtering`            | `vms_evaluated`       | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
-| `vms_powered_on`                 |                       | virtual machines powered on                                                              |
-| `vms_powered_off`                |                       | virtual machines powered off                                                             |
-| `vms_excluded_by_name`           |                       | virtual machines excluded based on fixed name values                                     |
-| `vms_excluded_by_folder`         |                       | virtual machines excluded based on folder IDs                                            |
-| `vms_excluded_by_power_state`    |                       | virtual machines excluded based on power state (powered off VMs are excluded by default) |
-| `vms_excluded_by_resource_pool`  |                       | virtual machines excluded based on resource pool name                                    |
-| `folders_all`                    |                       | all folders in the inventory                                                             |
-| `folders_excluded`               |                       | folders excluded by request                                                              |
-| `folders_included`               |                       | folders included by request (all non-listed folders excluded)                            |
-| `folders_evaluated`              |                       | folders remaining after inclusion/exclusion filtering logic is applied                   |
-| `resource_pools_all`             |                       | all resource pools in the inventory                                                      |
-| `resource_pools_excluded`        |                       | resource pools excluded by request                                                       |
-| `resource_pools_included`        |                       | resource pools included by request (all non-listed resource pools excluded)              |
-| `resource_pools_evaluated`       |                       | resource pools remaining after inclusion/exclusion filtering logic is applied            |
-| `vms_with_critical_power_uptime` |                       | virtual machines with a power uptime that has exceeded the given CRITICAL threshold      |
-| `vms_with_warning_power_uptime`  |                       | virtual machines with a power uptime that has exceeded the given WARNING threshold       |
+| Metric                           | Alias of              | Unit of Measurement | Description                                                                              |
+| -------------------------------- | --------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `time`                           |                       | milliseconds        | plugin runtime                                                                           |
+| `vms`                            | `vms_all`             |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_all`                        | `vms`                 |                     | all (visible) virtual machines in the inventory                                          |
+| `vms_evaluated`                  | `vms_after_filtering` |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_after_filtering`            | `vms_evaluated`       |                     | virtual machines after filtering, evaluated for plugin-specific threshold violations     |
+| `vms_powered_on`                 |                       |                     | virtual machines powered on                                                              |
+| `vms_powered_off`                |                       |                     | virtual machines powered off                                                             |
+| `vms_excluded_by_name`           |                       |                     | virtual machines excluded based on fixed name values                                     |
+| `vms_excluded_by_folder`         |                       |                     | virtual machines excluded based on folder IDs                                            |
+| `vms_excluded_by_power_state`    |                       |                     | virtual machines excluded based on power state (powered off VMs are excluded by default) |
+| `vms_excluded_by_resource_pool`  |                       |                     | virtual machines excluded based on resource pool name                                    |
+| `folders_all`                    |                       |                     | all folders in the inventory                                                             |
+| `folders_excluded`               |                       |                     | folders excluded by request                                                              |
+| `folders_included`               |                       |                     | folders included by request (all non-listed folders excluded)                            |
+| `folders_evaluated`              |                       |                     | folders remaining after inclusion/exclusion filtering logic is applied                   |
+| `resource_pools_all`             |                       |                     | all resource pools in the inventory                                                      |
+| `resource_pools_excluded`        |                       |                     | resource pools excluded by request                                                       |
+| `resource_pools_included`        |                       |                     | resource pools included by request (all non-listed resource pools excluded)              |
+| `resource_pools_evaluated`       |                       |                     | resource pools remaining after inclusion/exclusion filtering logic is applied            |
+| `vms_with_critical_power_uptime` |                       |                     | virtual machines with a power uptime that has exceeded the given CRITICAL threshold      |
+| `vms_with_warning_power_uptime`  |                       |                     | virtual machines with a power uptime that has exceeded the given WARNING threshold       |
 
 ## Optional evaluation
 


### PR DESCRIPTION
Convert remaining plugin doc metric lists to tables and fill with metric descriptions.

This commit also removes a metrics list left behind in one of the plugin docs from previous conversion work.

refs GH-809