### PR TITLE
Add guard against missing resource pool summary

### DIFF
--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -518,21 +518,33 @@ func ResourcePoolsMemoryReport(
 		// gather MOID to Name mappings for later lookup
 		rpIDtoNameIdx[rp.Self.Value] = rp.Name
 
-		rpMemoryUsage := rp.Summary.GetResourcePoolSummary().QuickStats.HostMemoryUsage * units.MB
-		rpMemoryPercentageUsed := MemoryUsedPercentage(rpMemoryUsage, maxMemoryUsageInBytes)
-		memoryPercentageUsedOfClusterCapacity := MemoryUsedPercentage(
-			rpMemoryUsage,
-			clusterMemoryInBytes,
-		)
-		fmt.Fprintf(
-			&report,
-			"* %s [Pool: (%s, %0.1f%%), Cluster: (%.2f%%)]%s",
-			rp.Name,
-			units.ByteSize(rpMemoryUsage),
-			rpMemoryPercentageUsed,
-			memoryPercentageUsedOfClusterCapacity,
-			nagios.CheckOutputEOL,
-		)
+		rpSummary := rp.Summary.GetResourcePoolSummary()
+		switch {
+		case rpSummary == nil:
+			fmt.Fprintf(
+				&report,
+				"* %s [Pool: (unavailable), Cluster: (unavailable)]%s",
+				rp.Name,
+				nagios.CheckOutputEOL,
+			)
+
+		default:
+			rpMemoryUsage := rpSummary.QuickStats.HostMemoryUsage * units.MB
+			rpMemoryPercentageUsed := MemoryUsedPercentage(rpMemoryUsage, maxMemoryUsageInBytes)
+			memoryPercentageUsedOfClusterCapacity := MemoryUsedPercentage(
+				rpMemoryUsage,
+				clusterMemoryInBytes,
+			)
+			fmt.Fprintf(
+				&report,
+				"* %s [Pool: (%s, %0.1f%%), Cluster: (%.2f%%)]%s",
+				rp.Name,
+				units.ByteSize(rpMemoryUsage),
+				rpMemoryPercentageUsed,
+				memoryPercentageUsedOfClusterCapacity,
+				nagios.CheckOutputEOL,
+			)
+		}
 	}
 
 	poweredVMs, numVMsPoweredOff := FilterVMsByPowerState(rpsVMs, false)


### PR DESCRIPTION
Update vsphere.ResourcePoolsMemoryReport func to gracefully emit "unavailable" for missing summary stats.

fixes GH-658