### PR TITLE
Fix implicit memory aliasing issues

### DIFF
--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -295,6 +295,10 @@ func main() {
 
 	// Debug logging for troubleshooting purposes.
 	for hostID, pairing := range h2dIdx {
+		// Reassign the iteration variable inside the loop to prevent implicit
+		// memory aliasing.
+		// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
+		hostID, pairing := hostID, pairing
 
 		dsNamesForHost := func(pairings vsphere.HostDatastoresPairing) string {
 			names := make([]string, len(pairing.Datastores))

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -876,6 +876,10 @@ func ListVMSnapshots(vm mo.VirtualMachine, w io.Writer) {
 
 		for _, snapTree := range snapTrees {
 
+			// G601: Implicit memory aliasing in for loop
+			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
+			snapTree := snapTree
+
 			daysAge := now.Sub(snapTree.CreateTime).Hours() / 24
 
 			fmt.Fprintf(
@@ -982,6 +986,10 @@ func NewSnapshotSummarySet(
 		}
 
 		for _, snapTree := range snapTrees {
+
+			// G601: Implicit memory aliasing in for loop
+			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
+			snapTree := snapTree
 
 			logger.Printf(
 				"Processing snapshot: [ID: %s, Name: %s, HasParent: %t]\n",


### PR DESCRIPTION
Two cases detected by gosec v2.17.0 (golangci-lint v1.54.2).

Those cases confirmed, another detected by using the Go 1.21 `loopvar=2` GC flag to surface loops which compile differently using the experimental changes to `for` loop semantics.

fixes GH-916