### PR TITLE
Fix `unused-parameter` revive linting errors

### DIFF
--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -301,9 +301,9 @@ func main() {
 		hostID, pairing := hostID, pairing
 
 		dsNamesForHost := func(pairings vsphere.HostDatastoresPairing) string {
-			names := make([]string, len(pairing.Datastores))
-			for i := range pairing.Datastores {
-				names[i] = pairing.Datastores[i].Name
+			names := make([]string, len(pairings.Datastores))
+			for i := range pairings.Datastores {
+				names[i] = pairings.Datastores[i].Name
 			}
 			return strings.Join(names, ", ")
 		}(pairing)

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -868,7 +868,7 @@ func ListVMSnapshots(vm mo.VirtualMachine, w io.Writer) {
 
 	var listFunc func(mo.VirtualMachine, []types.VirtualMachineSnapshotTree, *types.ManagedObjectReference)
 
-	listFunc = func(vm mo.VirtualMachine, snapTrees []types.VirtualMachineSnapshotTree, parent *types.ManagedObjectReference) {
+	listFunc = func(vm mo.VirtualMachine, snapTrees []types.VirtualMachineSnapshotTree, _ *types.ManagedObjectReference) {
 
 		if len(snapTrees) == 0 {
 			return

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -1261,7 +1261,7 @@ func getVMsCountUsingRootFolderContainerView(
 		logger.Printf(
 			"It took %v to execute getVMsCountUsingRootFolderContainerView func (and count %d VMs).\n",
 			time.Since(funcTimeStart),
-			len(allVMs),
+			len(*vms),
 		)
 	}(&allVMs)
 


### PR DESCRIPTION
Resolve multiple linting errors flagged by recent linter releases (golangci-lint, revive).