### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -562,8 +562,8 @@ var Usage = func() {
 	// `--help` flag and have it display within the Admin web UI.
 	flag.CommandLine.SetOutput(os.Stdout)
 
-	fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+	_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 	flag.PrintDefaults()
 }
 

--- a/internal/config/dsperf.go
+++ b/internal/config/dsperf.go
@@ -134,7 +134,7 @@ func (mvdsperf *MultiValueDSPerfPercentileSetFlag) String() string {
 	var output strings.Builder
 
 	for _, p := range percentiles {
-		fmt.Fprintf(&output,
+		_, _ = fmt.Fprintf(&output,
 			"{Percentile: %v, ThresholdVals: %+v}, ",
 			p,
 			(*mvdsperf)[p],
@@ -203,7 +203,7 @@ func (mvdsperf MultiValueDSPerfPercentileSetFlag) thresholdValues(state string) 
 			// )
 		}
 
-		fmt.Fprintf(&output,
+		_, _ = fmt.Fprintf(&output,
 			"{ Percentile: %v, ReadLatency: %+v, WriteLatency: %v, VMLatency: %v }, ",
 			p,
 			readLatency,

--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -1750,7 +1750,7 @@ func AlarmsReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Non-excluded Triggered Alarms detected:%s%s",
 		nagios.CheckOutputEOL,
@@ -1761,7 +1761,7 @@ func AlarmsReport(
 
 	switch {
 	case numTriggeredAlarmsToReport == 0:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None%s%s",
 			nagios.CheckOutputEOL,
@@ -1773,7 +1773,7 @@ func AlarmsReport(
 			// only look at non-excluded alarms
 			if !triggeredAlarms[i].Exclude {
 				alarmCtr++
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&report,
 					"* (%.2d) %s (type %s): %s%s",
 					alarmCtr,
@@ -1785,11 +1785,11 @@ func AlarmsReport(
 			}
 		}
 
-		fmt.Fprintf(&report, "%s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "%s", nagios.CheckOutputEOL)
 
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Excluded Triggered Alarms (as requested):%s%s",
 		nagios.CheckOutputEOL,
@@ -1798,7 +1798,7 @@ func AlarmsReport(
 
 	switch {
 	case triggeredAlarms.NumExcluded() == 0:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None%s%s",
 			nagios.CheckOutputEOL,
@@ -1810,7 +1810,7 @@ func AlarmsReport(
 			// only look at excluded alarms
 			if triggeredAlarms[i].Exclude {
 				alarmCtr++
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&report,
 					"* (%.2d) %s (type: %q, alarm name: %q, exclude reason: %q)%s",
 					alarmCtr,
@@ -1824,7 +1824,7 @@ func AlarmsReport(
 		}
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -1832,7 +1832,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s**NOTE: Explicit exclusions have precedence over inclusions**%s%s",
 		nagios.CheckOutputEOL,
@@ -1840,21 +1840,21 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Triggered Alarms (evaluated: %d, ignored: %d, total: %d)%s",
 		numTriggeredAlarmsToReport,
@@ -1863,20 +1863,20 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Acknowledged Triggered Alarms evaluated: %t%s",
 		triggeredAlarmFilters.EvaluateAcknowledgedAlarms,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Triggered Alarms to explicitly include%s",
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity types (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmEntityTypes),
@@ -1884,7 +1884,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity names (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmEntityNames),
@@ -1892,7 +1892,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity resource pools (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmEntityResourcePools),
@@ -1900,7 +1900,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** names (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmNames),
@@ -1908,7 +1908,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** descriptions (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmDescriptions),
@@ -1916,7 +1916,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** statuses (%d): [%v]%s",
 		len(triggeredAlarmFilters.IncludedAlarmStatuses),
@@ -1924,13 +1924,13 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Triggered Alarms to explicitly exclude%s",
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity types (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmEntityTypes),
@@ -1938,7 +1938,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity names (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmEntityNames),
@@ -1946,7 +1946,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** entity resource pools (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmEntityResourcePools),
@@ -1954,7 +1954,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** names (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmNames),
@@ -1962,7 +1962,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** descriptions (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmDescriptions),
@@ -1970,7 +1970,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"** statuses (%d): [%v]%s",
 		len(triggeredAlarmFilters.ExcludedAlarmStatuses),
@@ -1978,7 +1978,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Datacenters specified (%d): [%v]%s",
 		len(specifiedDatacenters),
@@ -1986,7 +1986,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Datacenters evaluated (%d): [%v]%s",
 		len(datacentersEvaluated),
@@ -1994,7 +1994,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Datacenters with Triggered Alarms (%d): [%v]%s",
 		len(triggeredAlarms.Datacenters()),
@@ -2002,7 +2002,7 @@ func AlarmsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Resource Pools with Triggered Alarms (%d): [%v]%s",
 		len(triggeredAlarms.ResourcePools()),

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -298,7 +298,7 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 		}
 
 		for _, vm := range vms {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s [Size: %s, Datastore Usage: %s]%s",
 				vm.Name,
@@ -308,12 +308,12 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 			)
 		}
 
-		fmt.Fprintf(w, nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(w, nagios.CheckOutputEOL)
 	}
 
 	switch {
 	case powerState == types.VirtualMachinePowerStatePoweredOn:
-		fmt.Fprint(
+		_, _ = fmt.Fprint(
 			w,
 			sectionHeader(
 				dsVMs.NumVMsPoweredOn(),
@@ -324,7 +324,7 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 		listVMs(w, dsVMs.VMsPoweredOn())
 
 	case powerState == types.VirtualMachinePowerStatePoweredOff:
-		fmt.Fprint(
+		_, _ = fmt.Fprint(
 			w,
 			sectionHeader(
 				dsVMs.NumVMsPoweredOff(),
@@ -334,7 +334,7 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 
 		listVMs(w, dsVMs.VMsPoweredOff())
 
-		fmt.Fprint(
+		_, _ = fmt.Fprint(
 			w,
 			sectionHeader(
 				dsVMs.NumVMsTemplates(),
@@ -1345,7 +1345,7 @@ func DatastoreSpaceUsageReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Datastore Space Summary:%s%s"+
 			"* Name: %s%s"+ //nolint:goconst
@@ -1371,7 +1371,7 @@ func DatastoreSpaceUsageReport(
 
 	printVMSummary(&report, dsUsageSummary.VMs, types.VirtualMachinePowerStatePoweredOff)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -1379,14 +1379,14 @@ func DatastoreSpaceUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,
@@ -1520,7 +1520,7 @@ func DatastorePerformanceReport(
 	// List metrics which exceed threshold.
 	if dsPerfSet.IsWarningState() || dsPerfSet.IsCriticalState() {
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"Metrics for datastore %q which exceed thresholds:%s",
 			dsPerfSet.Datastore.Name,
@@ -1533,7 +1533,7 @@ func DatastorePerformanceReport(
 				continue
 			}
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"%sResult %v (active): %s",
 				nagios.CheckOutputEOL,
@@ -1550,7 +1550,7 @@ func DatastorePerformanceReport(
 
 				// Skip emitting any metrics which don't exceed the thresholds.
 				if summary.IsCriticalState() || summary.IsWarningState() {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						&report,
 						"  * { Percentile: %d, RLatency: %.2f, WLatency: %.2f, VMLatency: %.2f, RIops: %.2f, WIops: %.2f, Interval: %d }%s",
 						percentile,
@@ -1566,7 +1566,7 @@ func DatastorePerformanceReport(
 			}
 		}
 
-		fmt.Fprintf(&report, nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, nagios.CheckOutputEOL)
 
 	}
 
@@ -1581,7 +1581,7 @@ func DatastorePerformanceReport(
 			"Full Collection of Performance Metrics for datastore %q (%d VMs):%s"
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		metricCollectionsHeaderTemplate,
 		dsPerfSet.Datastore.Name,
@@ -1601,7 +1601,7 @@ func DatastorePerformanceReport(
 			activeIndicator = "active"
 		}
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"%sResult %v (%s): %s",
 			nagios.CheckOutputEOL,
@@ -1617,7 +1617,7 @@ func DatastorePerformanceReport(
 			percentile := percentiles[i]
 			summary := perSummaryIndex.Entries[percentile]
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				// "\t* { Percentile: %d, Read Latency: %.2f, Write Latency: %.2f, VM Latency: %.2f, Read Iops: %.2f, Write Iops: %.2f, Interval: %d%s",
 				"  * { Percentile: %d, RLatency: %.2f, WLatency: %.2f, VMLatency: %.2f, RIops: %.2f, WIops: %.2f, Interval: %d }%s",
@@ -1633,13 +1633,13 @@ func DatastorePerformanceReport(
 		}
 	}
 
-	fmt.Fprintf(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprintf(&report, nagios.CheckOutputEOL)
 
 	printVMSummary(&report, dsPerfSet.VMs, types.VirtualMachinePowerStatePoweredOn)
 
 	printVMSummary(&report, dsPerfSet.VMs, types.VirtualMachinePowerStatePoweredOff)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -1647,14 +1647,14 @@ func DatastorePerformanceReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -614,7 +614,7 @@ func VirtualHardwareReport(
 	// least one outdated version to report
 	case hwvIndex.Count() > 1:
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"Virtual Hardware Summary%s%s",
 			nagios.CheckOutputEOL,
@@ -623,7 +623,7 @@ func VirtualHardwareReport(
 
 		for _, hwv := range hwvIndex.Versions() {
 			if !hwv.IsHighest() {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&report,
 					"version: %s, count: %d (outdated)\n",
 					hwv.String(),
@@ -631,7 +631,7 @@ func VirtualHardwareReport(
 				)
 				continue
 			}
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"version: %s, count: %d\n",
 				hwv.String(),
@@ -643,7 +643,7 @@ func VirtualHardwareReport(
 
 		// homogenous
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"All evaluated VMs are at hardware version %d.%s",
 			hwvIndex.Newest().VersionNumber(),
@@ -659,7 +659,7 @@ func VirtualHardwareReport(
 			minHardwareVersion,
 		)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"%sVirtual Machines in need of upgrade:%s%s",
 			nagios.CheckOutputEOL,
@@ -680,7 +680,7 @@ func VirtualHardwareReport(
 			hwVersion := newHardwareVersionString(vm.Config.Version)
 			hwVerNum := hwVersion.VersionNumber()
 			if hwVerNum < minHardwareVersion {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&report,
 					"* %s (%s)%s",
 					vm.Name,
@@ -700,7 +700,7 @@ func VirtualHardwareReport(
 		true,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Default Virtual Hardware Version: %d (%s) %s",
 		defaultHardwareVersion.VersionNumber(),
@@ -708,7 +708,7 @@ func VirtualHardwareReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Newest Virtual Hardware Version: %d (%s) %s",
 		hwvIndex.Newest().VersionNumber(),
@@ -716,7 +716,7 @@ func VirtualHardwareReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Oldest Virtual Hardware Version: %d (%s) %s",
 		hwvIndex.Oldest().VersionNumber(),

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -952,7 +952,7 @@ func H2D2VMsReport(
 
 	case len(vmDatastoresPairingIssues) > 0:
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"Mismatched Hosts / Datastores / Virtual Machines:%s%s",
 			nagios.CheckOutputEOL,
@@ -987,13 +987,13 @@ func H2D2VMsReport(
 		for _, vmName := range vmNames {
 			var dsNamesWithCA strings.Builder
 			for i, ds := range vmDatastoresPairingIssues[vmName].Datastores {
-				fmt.Fprintf(&dsNamesWithCA, "%q (%s)", ds.Name, ds.CustomAttribute.Value)
+				_, _ = fmt.Fprintf(&dsNamesWithCA, "%q (%s)", ds.Name, ds.CustomAttribute.Value)
 				if i != len(vmDatastoresPairingIssues[vmName].Datastores)-1 {
 					dsNamesWithCA.WriteString(", ")
 				}
 			}
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s: [Host: %q (%s), Datastores: %s]%s",
 				vmName,
@@ -1004,13 +1004,13 @@ func H2D2VMsReport(
 			)
 		}
 
-		fmt.Fprint(&report, nagios.CheckOutputEOL)
+		_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	default:
 
 		// homogenous
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"No mismatched Host/Datastore/VM pairings detected.%s%s",
 			nagios.CheckOutputEOL,
@@ -1019,7 +1019,7 @@ func H2D2VMsReport(
 
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -1029,7 +1029,7 @@ func H2D2VMsReport(
 
 	switch {
 	case ignoreMissingCA:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* As requested, Hosts and Datastores with missing Custom Attribute are ignored [Host: %q, Datastore: %q]%s",
 			hostCAName,
@@ -1038,7 +1038,7 @@ func H2D2VMsReport(
 		)
 
 	default:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* As requested, Hosts and Datastores with missing Custom Attribute is a fatal condition [Host: %q, Datastore: %q]%s",
 			hostCAName,
@@ -1050,7 +1050,7 @@ func H2D2VMsReport(
 	switch {
 	case len(hostsMissingCA) > 0:
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"Hosts missing Custom Attribute %q: %s%s",
 			hostCAName,
@@ -1059,7 +1059,7 @@ func H2D2VMsReport(
 		)
 
 		for _, hostName := range hostsMissingCA {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s%s",
 				hostName,
@@ -1069,7 +1069,7 @@ func H2D2VMsReport(
 
 	case len(datastoresMissingCA) > 0:
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"Datastores missing Custom Attribute %q: %s%s",
 			hostCAName,
@@ -1078,7 +1078,7 @@ func H2D2VMsReport(
 		)
 
 		for _, dsName := range datastoresMissingCA {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s%s",
 				dsName,
@@ -1086,7 +1086,7 @@ func H2D2VMsReport(
 			)
 		}
 	default:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* No Hosts or Datastores are missing specified Custom Attribute%s",
 			nagios.CheckOutputEOL,
@@ -1095,7 +1095,7 @@ func H2D2VMsReport(
 	}
 
 	if hostCAPrefixSeparator != "" || datastoreCAPrefixSeparator != "" {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* Custom Attribute Prefix Separator: [Host: %q, Datastore: %q]%s",
 			hostCAPrefixSeparator,
@@ -1112,7 +1112,7 @@ func H2D2VMsReport(
 		false,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Specified Datastores to exclude (%d): [%v]%s",
 		len(ignoredDatastores),

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -509,7 +509,7 @@ func HostSystemMemoryUsageReport(
 
 	vmsMemUsedPercentOfHost := (float64(vmsMemUsedBytes) / float64(hsUsageSummary.MemoryTotal)) * 100
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Host Summary:%s%s"+
 			"* Name: %s%s"+ //nolint:goconst
@@ -544,7 +544,7 @@ func HostSystemMemoryUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sVMs on host consuming memory (descending order):%s%s",
 		nagios.CheckOutputEOL,
@@ -560,7 +560,7 @@ func HostSystemMemoryUsageReport(
 		if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
 			hostMemUsedBytes := int64(vm.Summary.QuickStats.HostMemoryUsage) * units.MB
 			vmPercentOfHostMemUsed := float64(hostMemUsedBytes) / float64(hsUsageSummary.MemoryTotal) * 100
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s (Memory: %v, Host Memory Usage: %2.2f%%)%s",
 				vm.Name,
@@ -572,14 +572,14 @@ func HostSystemMemoryUsageReport(
 	}
 
 	if vmsPoweredOn == 0 {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible)%s",
 			nagios.CheckOutputEOL,
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sVMs on host not consuming memory:%s%s",
 		nagios.CheckOutputEOL,
@@ -593,7 +593,7 @@ func HostSystemMemoryUsageReport(
 
 	for _, vm := range hsVMs {
 		if vm.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s%s",
 				vm.Name,
@@ -603,14 +603,14 @@ func HostSystemMemoryUsageReport(
 	}
 
 	if vmsPoweredOff == 0 {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible)%s",
 			nagios.CheckOutputEOL,
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -618,14 +618,14 @@ func HostSystemMemoryUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,
@@ -726,7 +726,7 @@ func HostSystemCPUUsageReport(
 
 	vmsCPUUsedPercentOfHost := (float64(vmsCPUUsage) / hsUsageSummary.CPUTotal) * 100
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Host Summary:%s%s"+
 			"* Name: %s%s"+ //nolint:goconst
@@ -761,7 +761,7 @@ func HostSystemCPUUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sVMs on host consuming CPU (descending order):%s%s",
 		nagios.CheckOutputEOL,
@@ -777,7 +777,7 @@ func HostSystemCPUUsageReport(
 		if vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn {
 			hostCPUUsed := int64(vm.Summary.QuickStats.OverallCpuUsage) * MHz
 			vmPercentOfHostCPUUsed := (float64(hostCPUUsed) / hsUsageSummary.CPUTotal) * 100
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s (CPU: %s, Host CPU Usage: %2.2f%%)%s",
 				vm.Name,
@@ -789,14 +789,14 @@ func HostSystemCPUUsageReport(
 	}
 
 	if vmsPoweredOn == 0 {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible)%s",
 			nagios.CheckOutputEOL,
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sVMs on host not consuming CPU:%s%s",
 		nagios.CheckOutputEOL,
@@ -810,7 +810,7 @@ func HostSystemCPUUsageReport(
 
 	for _, vm := range hsVMs {
 		if vm.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s%s",
 				vm.Name,
@@ -820,14 +820,14 @@ func HostSystemCPUUsageReport(
 	}
 
 	if vmsPoweredOff == 0 {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible)%s",
 			nagios.CheckOutputEOL,
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -835,14 +835,14 @@ func HostSystemCPUUsageReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -663,7 +663,7 @@ func ResourcePoolsMemoryReport(
 
 	rpIDtoNameIdx := make(map[string]string)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Memory usage by Resource Pool:%s%s",
 		nagios.CheckOutputEOL,
@@ -677,7 +677,7 @@ func ResourcePoolsMemoryReport(
 		rpSummary := rp.Summary.GetResourcePoolSummary()
 		switch {
 		case rpSummary == nil:
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s [Pool: (unavailable), Cluster: (unavailable)]%s",
 				rp.Name,
@@ -691,7 +691,7 @@ func ResourcePoolsMemoryReport(
 				rpMemoryUsage,
 				clusterMemoryInBytes,
 			)
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s [Pool: (%s, %0.1f%%), Cluster: (%.2f%%)]%s",
 				rp.Name,
@@ -714,7 +714,7 @@ func ResourcePoolsMemoryReport(
 	poweredVMs, numVMsPoweredOff := FilterVMsByPowerState(vms, false)
 	numVMsPoweredOn := len(poweredVMs)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sTen VMS consuming most memory:%s%s",
 		nagios.CheckOutputEOL,
@@ -724,7 +724,7 @@ func ResourcePoolsMemoryReport(
 
 	switch {
 	case numVMsPoweredOn == 0:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible); %d powered off%s",
 			numVMsPoweredOff,
@@ -747,7 +747,7 @@ func ResourcePoolsMemoryReport(
 			hostMemUsedBytes := int64(vm.Summary.QuickStats.HostMemoryUsage) * units.MB
 			rpName := rpIDtoNameIdx[vm.ResourcePool.Value]
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s [Mem: %s, Pool: %s]%s",
 				vm.Name,
@@ -759,7 +759,7 @@ func ResourcePoolsMemoryReport(
 
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sTen VMs most recently powered on:%s%s",
 		nagios.CheckOutputEOL,
@@ -769,7 +769,7 @@ func ResourcePoolsMemoryReport(
 
 	switch {
 	case len(poweredVMs) == 0:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible); %d powered off%s",
 			numVMsPoweredOff,
@@ -794,7 +794,7 @@ func ResourcePoolsMemoryReport(
 			uptimeDays := uptime.Hours() / 24
 			rpName := rpIDtoNameIdx[vm.ResourcePool.Value]
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s: [Uptime: %.2f days, Mem: %s, Pool: %s]%s",
 				vm.Name,
@@ -807,7 +807,7 @@ func ResourcePoolsMemoryReport(
 
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%s---%s%s",
 		nagios.CheckOutputEOL,
@@ -815,21 +815,21 @@ func ResourcePoolsMemoryReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Specified Resource Pools to explicitly include (%d): [%v]%s",
 		len(vmsFilterOptions.ResourcePoolsIncluded),
@@ -837,7 +837,7 @@ func ResourcePoolsMemoryReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Specified Resource Pools to explicitly exclude (%d): [%v]%s",
 		len(vmsFilterOptions.ResourcePoolsExcluded),
@@ -845,7 +845,7 @@ func ResourcePoolsMemoryReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Resource Pools evaluated (%d of %d): [%v]%s",
 		vmsFilterResults.NumRPsAfterFiltering(),

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -882,7 +882,7 @@ func ListVMSnapshots(vm mo.VirtualMachine, w io.Writer) {
 
 			daysAge := now.Sub(snapTree.CreateTime).Hours() / 24
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"Snapshot [Name: %v, Age: %v, ID: %v, MOID: %v, Active: %t]\n",
 				snapTree.Name,
@@ -1425,7 +1425,7 @@ func writeSnapshotsListEntries(
 		switch {
 		case exceeding:
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"Snapshots%sexceeding WARNING (%d %s) or CRITICAL (%d %s) %s thresholds:%s%s",
 				forWhat,
@@ -1439,7 +1439,7 @@ func writeSnapshotsListEntries(
 			)
 		default:
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"%sSnapshots%s*not yet* exceeding %s thresholds:%s%s",
 				nagios.CheckOutputEOL,
@@ -1470,7 +1470,7 @@ func writeSnapshotsListEntries(
 		for _, snapSet := range snapshotSummarySets {
 			for _, snap := range snapSet.Snapshots {
 				if snap.IsAgeCriticalState() || snap.IsAgeWarningState() {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
 						snap.VMName,
@@ -1496,7 +1496,7 @@ func writeSnapshotsListEntries(
 		// point
 		for _, snapSet := range setsWithExcessSnaps {
 			for _, snap := range snapSet.Snapshots {
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					w,
 					listEntryTemplate,
 					snap.VMName,
@@ -1517,7 +1517,7 @@ func writeSnapshotsListEntries(
 		for _, snapSet := range snapshotSummarySets {
 			if snapSet.IsSizeWarningState() || snapSet.IsSizeCriticalState() {
 				for _, snap := range snapSet.Snapshots {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
 						snap.VMName,
@@ -1532,7 +1532,7 @@ func writeSnapshotsListEntries(
 		}
 
 	default:
-		fmt.Fprintln(w, "* None detected")
+		_, _ = fmt.Fprintln(w, "* None detected")
 	}
 
 	switch {
@@ -1553,7 +1553,7 @@ func writeSnapshotsListEntries(
 			for _, snap := range snapSet.Snapshots {
 				if !(snap.IsAgeCriticalState() ||
 					snap.IsAgeWarningState()) {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
 						snap.VMName,
@@ -1573,7 +1573,7 @@ func writeSnapshotsListEntries(
 		for _, snapSet := range snapshotSummarySets {
 			if !(snapSet.IsCountCriticalState() || snapSet.IsCountWarningState()) {
 				for _, snap := range snapSet.Snapshots {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
 						snap.VMName,
@@ -1594,7 +1594,7 @@ func writeSnapshotsListEntries(
 			if !(snapSet.IsSizeWarningState() ||
 				snapSet.IsSizeCriticalState()) {
 				for _, snap := range snapSet.Snapshots {
-					fmt.Fprintf(
+					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
 						snap.VMName,
@@ -1609,7 +1609,7 @@ func writeSnapshotsListEntries(
 		}
 
 	default:
-		fmt.Fprintln(w, "* None detected")
+		_, _ = fmt.Fprintln(w, "* None detected")
 	}
 
 }

--- a/internal/vsphere/tools.go
+++ b/internal/vsphere/tools.go
@@ -184,7 +184,7 @@ func VMToolsReport(
 		})
 
 		for idx, vm := range vmsWithIssues {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&vmsReport,
 				"* %02d) %s (%s, %s)%s",
 				idx+1,
@@ -196,7 +196,7 @@ func VMToolsReport(
 		}
 
 	default:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&vmsReport,
 			"* No VMware Tools issues detected.%s",
 			nagios.CheckOutputEOL,

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -102,7 +102,7 @@ func VirtualCPUsReport(
 
 	// This is shown regardless of whether the plugin is considered to be in a
 	// non-OK state.
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&vmsReport,
 		"* vCPUs%s** Allocated: %d (%.1f%%)%s** Max Allowed: %d%s",
 		nagios.CheckOutputEOL,
@@ -113,7 +113,7 @@ func VirtualCPUsReport(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&vmsReport,
 		"%sTop 10 vCPU consumers:%s%s",
 		nagios.CheckOutputEOL,
@@ -135,10 +135,10 @@ func VirtualCPUsReport(
 
 	switch {
 	case len(topTen) == 0:
-		fmt.Fprintf(&vmsReport, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&vmsReport, "* None %s", nagios.CheckOutputEOL)
 	default:
 		for _, vm := range topTen {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&vmsReport,
 				"* %s (%d vCPUs)%s",
 				vm.Name,
@@ -148,7 +148,7 @@ func VirtualCPUsReport(
 		}
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&vmsReport,
 		"%sTen most recently started VMs:%s%s",
 		nagios.CheckOutputEOL,
@@ -178,13 +178,13 @@ func VirtualCPUsReport(
 
 	switch {
 	case len(bottomTen) == 0:
-		fmt.Fprintf(&vmsReport, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&vmsReport, "* None %s", nagios.CheckOutputEOL)
 	default:
 		for _, vm := range bottomTen {
 			uptime := time.Duration(vm.Summary.QuickStats.UptimeSeconds) * time.Second
 			uptimeDays := uptime.Hours() / 24
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&vmsReport,
 				"* %s: (%.2f days)%s",
 				vm.Name,

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -2551,7 +2551,7 @@ func VMPowerCycleUptimeReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"VMs with high power cycle uptime:%s%s",
 		nagios.CheckOutputEOL,
@@ -2579,7 +2579,7 @@ func VMPowerCycleUptimeReport(
 			uptime := time.Duration(vm.Summary.QuickStats.UptimeSeconds) * time.Second
 			uptimeDays := uptime.Hours() / 24
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s: %.2f days%s",
 				vm.Name,
@@ -2589,9 +2589,9 @@ func VMPowerCycleUptimeReport(
 		}
 	default:
 
-		fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"%sTop 10 VMs, not yet exceeding power cycle uptime thresholds:%s%s",
 			nagios.CheckOutputEOL,
@@ -2602,13 +2602,13 @@ func VMPowerCycleUptimeReport(
 		topTen := uptimeSummary.TopTenOK()
 		switch {
 		case len(topTen) == 0:
-			fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
+			_, _ = fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
 		default:
 			for _, vm := range topTen {
 				uptime := time.Duration(vm.Summary.QuickStats.UptimeSeconds) * time.Second
 				uptimeDays := uptime.Hours() / 24
 
-				fmt.Fprintf(
+				_, _ = fmt.Fprintf(
 					&report,
 					"* %s: %.2f days%s",
 					vm.Name,
@@ -2620,7 +2620,7 @@ func VMPowerCycleUptimeReport(
 
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%sTen most recently started VMs:%s%s",
 		nagios.CheckOutputEOL,
@@ -2631,13 +2631,13 @@ func VMPowerCycleUptimeReport(
 	bottomTen := uptimeSummary.BottomTenOK()
 	switch {
 	case len(bottomTen) == 0:
-		fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
 	default:
 		for _, vm := range bottomTen {
 			uptime := time.Duration(vm.Summary.QuickStats.UptimeSeconds) * time.Second
 			uptimeDays := uptime.Hours() / 24
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s: %.2f days%s",
 				vm.Name,
@@ -2721,7 +2721,7 @@ func VMDiskConsolidationReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"VMs requiring disk consolidation:%s%s",
 		nagios.CheckOutputEOL,
@@ -2736,7 +2736,7 @@ func VMDiskConsolidationReport(
 		})
 
 		for _, vm := range vmsNeedingConsolidation {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s (%s)%s",
 				vm.Name,
@@ -2747,7 +2747,7 @@ func VMDiskConsolidationReport(
 
 	default:
 
-		fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
 
 	}
 	vmFilterResultsReportTrailer(
@@ -2824,7 +2824,7 @@ func VMInteractiveQuestionReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"VMs requiring interactive response:%s%s",
 		nagios.CheckOutputEOL,
@@ -2862,7 +2862,7 @@ func VMInteractiveQuestionReport(
 				))
 			}
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				&report,
 				"* %s (%q [%s])%s",
 				vm.Name,
@@ -2874,7 +2874,7 @@ func VMInteractiveQuestionReport(
 
 	default:
 
-		fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None %s", nagios.CheckOutputEOL)
 
 	}
 
@@ -2983,7 +2983,7 @@ func VMBackupViaCAReport(
 		backupDateCAVal := vm.CustomAttributes[vm.BackupDateCAName]
 		backupDateMetadataVal := vm.CustomAttributes[vm.BackupMetadataCAName]
 
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* %s%s",
 			vm.Name,
@@ -2991,7 +2991,7 @@ func VMBackupViaCAReport(
 		)
 
 		if vm.HasBackup() {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"\t** %s: %t%s",
 				"Old Backup",
@@ -2999,7 +2999,7 @@ func VMBackupViaCAReport(
 				nagios.CheckOutputEOL,
 			)
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"\t** %s: %s%s",
 				"Backup age (formatted)",
@@ -3007,7 +3007,7 @@ func VMBackupViaCAReport(
 				nagios.CheckOutputEOL,
 			)
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"\t** %s: %d%s",
 				"Backup age (in days)",
@@ -3017,7 +3017,7 @@ func VMBackupViaCAReport(
 		}
 
 		if backupDateCAVal != "" {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"\t** %s (raw value): %q%s",
 				vm.BackupDateCAName,
@@ -3027,7 +3027,7 @@ func VMBackupViaCAReport(
 		}
 
 		if backupDateMetadataVal != "" {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"\t** %s: %q%s",
 				vm.BackupMetadataCAName,
@@ -3037,7 +3037,7 @@ func VMBackupViaCAReport(
 		}
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"VMs without backups:%s%s",
 		nagios.CheckOutputEOL,
@@ -3045,10 +3045,10 @@ func VMBackupViaCAReport(
 	)
 	switch {
 	case vmsWithBackup.NumWithoutBackups() == 0:
-		fmt.Fprintf(&report, "* None%s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None%s", nagios.CheckOutputEOL)
 
 	case vmsWithBackup.NumWithoutBackups() > vmPrintLimit:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* %d VMs without backups; output limit of %d reached, omitting list of VMs%s",
 			vmsWithBackup.NumWithoutBackups(),
@@ -3062,9 +3062,9 @@ func VMBackupViaCAReport(
 			}
 		}
 	}
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"VMs with old backups: %s%s",
 		nagios.CheckOutputEOL,
@@ -3072,10 +3072,10 @@ func VMBackupViaCAReport(
 	)
 	switch {
 	case vmsWithBackup.NumOldBackups() == 0:
-		fmt.Fprintf(&report, "* None%s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(&report, "* None%s", nagios.CheckOutputEOL)
 
 	case vmsWithBackup.NumOldBackups() > vmPrintLimit:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* %d VMs with old backups; output limit of %d reached, omitting list of VMs%s",
 			vmsWithBackup.NumOldBackups(),
@@ -3090,28 +3090,28 @@ func VMBackupViaCAReport(
 			}
 		}
 	}
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Virtual Machines Backup Summary: %s%s",
 		nagios.CheckOutputEOL,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Missing Backups: %d%s",
 		vmsWithBackup.NumWithoutBackups(),
 		nagios.CheckOutputEOL,
 	)
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* With Backups: %d%s",
 		vmsWithBackup.NumBackups(),
 		nagios.CheckOutputEOL,
 	)
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* Old Backups: %d%s",
 		vmsWithBackup.NumOldBackups(),
@@ -3120,7 +3120,7 @@ func VMBackupViaCAReport(
 
 	vmWithOldestBackup := vmsWithBackup.VMWithOldestBackup()
 	if vmWithOldestBackup != nil {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* Oldest backup: %s (%s)%s",
 			vmWithOldestBackup.Name,
@@ -3131,7 +3131,7 @@ func VMBackupViaCAReport(
 
 	vmWithYoungestBackup := vmsWithBackup.VMWithYoungestBackup()
 	if vmWithYoungestBackup != nil {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			&report,
 			"* Most recent backup: %s (%s)%s",
 			vmWithYoungestBackup.Name,
@@ -3209,28 +3209,28 @@ func VMListReport(
 
 	var report strings.Builder
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"Summary of inventory before before any filtering was applied:%s%s",
 		nagios.CheckOutputEOL,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* %d Virtual Machines%s",
 		vmsFilterResults.NumVMsAll(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* %d Resource Pools%s",
 		vmsFilterResults.NumRPsAll(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"* %d Folders%s",
 		vmsFilterResults.NumFoldersAll(),
@@ -3247,7 +3247,7 @@ func VMListReport(
 		vmsFilterResults.VMsAfterResourcePoolFiltering,
 	)
 
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	vmListReportFilteringBeforeAfterResults(
 		&report,
@@ -3259,7 +3259,7 @@ func VMListReport(
 		vmsFilterResults.VMsAfterFolderFiltering,
 	)
 
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	vmListReportFilteringBeforeAfterResults(
 		&report,
@@ -3271,7 +3271,7 @@ func VMListReport(
 		vmsFilterResults.VMsAfterVMNameFiltering,
 	)
 
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	vmListReportFilteringBeforeAfterResults(
 		&report,
@@ -3283,11 +3283,11 @@ func VMListReport(
 		vmsFilterResults.VMsAfterPowerStateFiltering,
 	)
 
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	vmListReportAfterAllFiltering(&report, vmsFilterResults)
 
-	fmt.Fprint(&report, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(&report, nagios.CheckOutputEOL)
 
 	vmFilterResultsReportTrailer(
 		&report,
@@ -3301,7 +3301,7 @@ func VMListReport(
 }
 
 func vmListReportAfterAllFiltering(w io.Writer, vmsFilterResults VMsFilterResults) {
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"%s(%d of %d) VMs after all filtering was applied:%s%s",
 		nagios.CheckOutputEOL,
@@ -3313,7 +3313,7 @@ func vmListReportAfterAllFiltering(w io.Writer, vmsFilterResults VMsFilterResult
 
 	switch {
 	case len(vmsFilterResults.VMsAfterFiltering()) == vmsFilterResults.NumVMsAll():
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"No filtering applied: %d VMs remain.%s",
 			vmsFilterResults.NumVMsAll(),
@@ -3321,35 +3321,35 @@ func vmListReportAfterAllFiltering(w io.Writer, vmsFilterResults VMsFilterResult
 		)
 
 	case len(vmsFilterResults.VMsAfterFiltering()) == len(vmsFilterResults.VMsAfterResourcePoolFiltering()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as after resource pool filtering.%s",
 			nagios.CheckOutputEOL,
 		)
 
 	case len(vmsFilterResults.VMsAfterFiltering()) == len(vmsFilterResults.VMsAfterFolderFiltering()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as after folder filtering.%s",
 			nagios.CheckOutputEOL,
 		)
 
 	case len(vmsFilterResults.VMsAfterFiltering()) == len(vmsFilterResults.VMsAfterVMNameFiltering()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as after VM name filtering.%s",
 			nagios.CheckOutputEOL,
 		)
 
 	case len(vmsFilterResults.VMsAfterFiltering()) == len(vmsFilterResults.VMsAfterPowerStateFiltering()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as after VM power state filtering.%s",
 			nagios.CheckOutputEOL,
 		)
 	default:
 		for _, vmName := range vmsFilterResults.VMNamesAfterFiltering() {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s%s",
 				vmName,
@@ -3377,7 +3377,7 @@ func vmFilterResultsReportTrailer(
 	}()
 
 	if emitSeparator {
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"%s---%s%s",
 			nagios.CheckOutputEOL,
@@ -3386,21 +3386,21 @@ func vmFilterResultsReportTrailer(
 		)
 	}
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* vSphere environment: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Plugin User Agent: %s%s",
 		c.Client.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* VMs evaluated: %d of %d%s",
 		len(vmsFilterResults.VMsAfterFiltering()),
@@ -3408,14 +3408,14 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Powered off VMs evaluated: %t%s",
 		vmsFilterOptions.IncludePoweredOff,
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Specified VMs to exclude (%d): [%v]%s",
 		len(vmsFilterOptions.VirtualMachineNamesExcluded),
@@ -3423,7 +3423,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Specified Folders to explicitly include (%d): [%v]%s",
 		len(vmsFilterOptions.FoldersIncluded),
@@ -3431,7 +3431,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Specified Folders to explicitly exclude (%d): [%v]%s",
 		len(vmsFilterOptions.FoldersExcluded),
@@ -3439,7 +3439,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Folders evaluated: %d of %d%s",
 		vmsFilterResults.NumFoldersAfterFiltering(),
@@ -3447,7 +3447,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Specified Resource Pools to explicitly include (%d): [%v]%s",
 		len(vmsFilterOptions.ResourcePoolsIncluded),
@@ -3455,7 +3455,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Specified Resource Pools to explicitly exclude (%d): [%v]%s",
 		len(vmsFilterOptions.ResourcePoolsExcluded),
@@ -3463,7 +3463,7 @@ func vmFilterResultsReportTrailer(
 		nagios.CheckOutputEOL,
 	)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"* Resource Pools evaluated (%d of %d): [%v]%s",
 		vmsFilterResults.NumRPsAfterFiltering(),
@@ -3501,7 +3501,7 @@ func vmListReportFilteringBeforeAfterResults(
 	currentAfterFilterFunc func() []mo.VirtualMachine,
 ) {
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"%s(%d of %d) VMs before %s filtering was applied:%s%s",
 		nagios.CheckOutputEOL,
@@ -3519,14 +3519,14 @@ func vmListReportFilteringBeforeAfterResults(
 
 	switch {
 	case previousAfterFilterFunc == nil:
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* No filtering applied yet; skipping listing of all VMs.%s",
 			nagios.CheckOutputEOL,
 		)
 
 	case len(currentBeforeFilterFunc()) == len(previousAfterFilterFunc()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as after %s filtering.%s",
 			previousAfterFilterDesc,
@@ -3535,7 +3535,7 @@ func vmListReportFilteringBeforeAfterResults(
 
 	default:
 		for _, vm := range currentBeforeFilterFunc() {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s%s",
 				vm.Name,
@@ -3544,9 +3544,9 @@ func vmListReportFilteringBeforeAfterResults(
 		}
 	}
 
-	fmt.Fprint(w, nagios.CheckOutputEOL)
+	_, _ = fmt.Fprint(w, nagios.CheckOutputEOL)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		w,
 		"%s(%d of %d) VMs after %s filtering was applied:%s%s",
 		nagios.CheckOutputEOL,
@@ -3560,7 +3560,7 @@ func vmListReportFilteringBeforeAfterResults(
 	switch {
 	case currentAfterFilterFunc != nil && currentBeforeFilterFunc == nil:
 		for _, vm := range currentAfterFilterFunc() {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s%s",
 				vm.Name,
@@ -3569,7 +3569,7 @@ func vmListReportFilteringBeforeAfterResults(
 		}
 
 	case len(currentAfterFilterFunc()) == len(currentBeforeFilterFunc()):
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			"* Same list as before %s filtering.%s",
 			currentFilterDesc,
@@ -3578,7 +3578,7 @@ func vmListReportFilteringBeforeAfterResults(
 
 	default:
 		for _, vm := range currentAfterFilterFunc() {
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				"* %s%s",
 				vm.Name,


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
