### PR TITLE
Fix gosec G115 linting errors

### DIFF
--- a/cmd/check_vmware_vcpus/main.go
+++ b/cmd/check_vmware_vcpus/main.go
@@ -157,9 +157,9 @@ func main() {
 
 	// here we diverge from VMware Tools plugin
 
-	var vCPUsAllocated int32
+	var vCPUsAllocated int64
 	for _, vm := range vmsFilterResults.VMsAfterFiltering() {
-		vCPUsAllocated += vm.Summary.Config.NumCpu
+		vCPUsAllocated += int64(vm.Summary.Config.NumCpu)
 		log.Debug().
 			Str("vm_name", vm.Name).
 			Int32("num_vcpu", vm.Summary.Config.NumCpu).
@@ -167,22 +167,22 @@ func main() {
 	}
 
 	log.Debug().
-		Int32("vcpus_allocated", vCPUsAllocated).
+		Int64("vcpus_allocated", vCPUsAllocated).
 		Msg("Finished counting vCPUs")
 
-	vCPUsPercentageUsedOfAllowed := float32(vCPUsAllocated) / float32(cfg.VCPUsMaxAllowed) * 100
-	var vCPUsRemaining int32
+	vCPUsPercentageUsedOfAllowed := float64(vCPUsAllocated) / float64(cfg.VCPUsMaxAllowed) * 100
+	var vCPUsRemaining int64
 
 	switch {
-	case vCPUsAllocated > int32(cfg.VCPUsMaxAllowed):
+	case vCPUsAllocated > int64(cfg.VCPUsMaxAllowed):
 		vCPUsRemaining = 0
 	default:
-		vCPUsRemaining = int32(cfg.VCPUsMaxAllowed) - vCPUsAllocated
+		vCPUsRemaining = int64(cfg.VCPUsMaxAllowed) - vCPUsAllocated
 	}
 
 	log.Debug().
-		Float32("vcpus_usage", vCPUsPercentageUsedOfAllowed).
-		Int32("vcpus_remaining", vCPUsRemaining).
+		Float64("vcpus_usage", vCPUsPercentageUsedOfAllowed).
+		Int64("vcpus_remaining", vCPUsRemaining).
 		Msg("")
 
 	log.Debug().Msg("Compiling Performance Data details")
@@ -234,14 +234,14 @@ func main() {
 		Int("vms_after_filtering", vmsFilterResults.NumVMsAfterFiltering()).
 		Int("vms_excluded_by_name", vmsFilterResults.NumVMsExcludedByName()).
 		Int("vms_excluded_by_power_state", vmsFilterResults.NumVMsExcludedByPowerState()).
-		Float32("vcpus_usage", vCPUsPercentageUsedOfAllowed).
-		Int32("vcpus_used", vCPUsAllocated).
-		Int32("vcpus_remaining", vCPUsRemaining).
+		Float64("vcpus_usage", vCPUsPercentageUsedOfAllowed).
+		Int64("vcpus_used", vCPUsAllocated).
+		Int64("vcpus_remaining", vCPUsRemaining).
 		Logger()
 
 	log.Debug().Msg("Evaluating vCPU usage")
 	switch {
-	case vCPUsPercentageUsedOfAllowed > float32(cfg.VCPUsAllocatedCritical):
+	case vCPUsPercentageUsedOfAllowed > float64(cfg.VCPUsAllocatedCritical):
 
 		log.Error().Msg("vCPUs allocation CRITICAL")
 
@@ -266,7 +266,7 @@ func main() {
 
 		return
 
-	case vCPUsPercentageUsedOfAllowed > float32(cfg.VCPUsAllocatedWarning):
+	case vCPUsPercentageUsedOfAllowed > float64(cfg.VCPUsAllocatedWarning):
 
 		log.Error().Msg("vCPUs allocation WARNING")
 

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -28,7 +28,7 @@ var ErrVCPUsUsageThresholdCrossed = errors.New("vCPUS allocation exceeds specifi
 func VirtualCPUsOneLineCheckSummary(
 	stateLabel string,
 	vmsFilterResults VMsFilterResults,
-	vCPUsAllocated int32,
+	vCPUsAllocated int64,
 	vCPUsMax int,
 ) string {
 
@@ -41,12 +41,12 @@ func VirtualCPUsOneLineCheckSummary(
 		)
 	}()
 
-	vCPUsPercentageUsed := float32(vCPUsAllocated) / float32(vCPUsMax) * 100
+	vCPUsPercentageUsed := float64(vCPUsAllocated) / float64(vCPUsMax) * 100
 
 	switch {
 
-	case vCPUsAllocated > int32(vCPUsMax):
-		vCPUsOverage := vCPUsAllocated - int32(vCPUsMax)
+	case vCPUsAllocated > int64(vCPUsMax):
+		vCPUsOverage := vCPUsAllocated - int64(vCPUsMax)
 		return fmt.Sprintf(
 			"%s: %d vCPUs allocated (%.1f%%); %d more allocated than %d allowed"+
 				" (evaluated %d VMs, %d Resource Pools)",
@@ -60,7 +60,7 @@ func VirtualCPUsOneLineCheckSummary(
 		)
 
 	default:
-		vCPUsRemaining := int32(vCPUsMax) - vCPUsAllocated
+		vCPUsRemaining := int64(vCPUsMax) - vCPUsAllocated
 		return fmt.Sprintf(
 			"%s: %d vCPUs allocated (%.1f%%); %d more remaining from %d allowed"+
 				" (evaluated %d VMs, %d Resource Pools)",
@@ -85,7 +85,7 @@ func VirtualCPUsReport(
 	c *vim25.Client,
 	vmsFilterOptions VMsFilterOptions,
 	vmsFilterResults VMsFilterResults,
-	vCPUsAllocated int32,
+	vCPUsAllocated int64,
 	vCPUsMax int,
 ) string {
 


### PR DESCRIPTION
Fix `G115: integer overflow conversion int -> int32` linting errors.

While in this case not a security issue and in practice unlikely to actually overflow, we go ahead and use 64 bit types for conversion to avoid the potential issue entirely.