### PR TITLE
Fix `copyloopvar` linting errors

### DIFF
--- a/cmd/check_vmware_hs2ds2vms/main.go
+++ b/cmd/check_vmware_hs2ds2vms/main.go
@@ -298,7 +298,10 @@ func main() {
 		// Reassign the iteration variable inside the loop to prevent implicit
 		// memory aliasing.
 		// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
-		hostID, pairing := hostID, pairing
+		//
+		// NOTE: Not needed as of Go 1.22.
+		//
+		// hostID, pairing := hostID, pairing
 
 		dsNamesForHost := func(pairings vsphere.HostDatastoresPairing) string {
 			names := make([]string, len(pairings.Datastores))

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -875,10 +875,12 @@ func ListVMSnapshots(vm mo.VirtualMachine, w io.Writer) {
 		}
 
 		for _, snapTree := range snapTrees {
-
 			// G601: Implicit memory aliasing in for loop
 			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
-			snapTree := snapTree
+			//
+			// NOTE: Not needed as of Go 1.22.
+			//
+			// snapTree := snapTree
 
 			daysAge := now.Sub(snapTree.CreateTime).Hours() / 24
 
@@ -986,10 +988,12 @@ func NewSnapshotSummarySet(
 		}
 
 		for _, snapTree := range snapTrees {
-
 			// G601: Implicit memory aliasing in for loop
 			// https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop
-			snapTree := snapTree
+			//
+			// NOTE: Not needed as of Go 1.22.
+			//
+			// snapTree := snapTree
 
 			logger.Printf(
 				"Processing snapshot: [ID: %s, Name: %s, HasParent: %t]\n",


### PR DESCRIPTION
Comment out workarounds for G601: Implicit memory aliasing.

refs GH-1395