### PR TITLE
Fix setting for disabling Dependabot auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -180,4 +180,4 @@ updates:
       - dependency-type: "all"
     commit-message:
       prefix: "Build Image"
-    rebase-strategy: "disabled
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Add missing closing quote for `rebase-strategy` setting.