### PR TITLE
Add explicit metadata section header in footer

### DIFF
--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -1824,13 +1824,7 @@ func AlarmsReport(
 		}
 	}
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,

--- a/internal/vsphere/constants.go
+++ b/internal/vsphere/constants.go
@@ -58,6 +58,13 @@ const (
 	snapshotThresholdTypeSizeSuffix  string = "GB"
 )
 
+// used with VM report trailer
+const (
+	// defaultSeparatorText      string = "---"
+	skipEmittingSeparator     string = ""
+	environmentMetadataHeader string = "Environment info/metadata:"
+)
+
 // Substring filtering keywords supported by
 // TriggeredAlarms.filterBySubstring() method
 const (

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -1371,13 +1371,7 @@ func DatastoreSpaceUsageReport(
 
 	printVMSummary(&report, dsUsageSummary.VMs, types.VirtualMachinePowerStatePoweredOff)
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,
@@ -1639,13 +1633,7 @@ func DatastorePerformanceReport(
 
 	printVMSummary(&report, dsPerfSet.VMs, types.VirtualMachinePowerStatePoweredOff)
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,

--- a/internal/vsphere/emit.go
+++ b/internal/vsphere/emit.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Adam Chalkley
+//
+// https://github.com/atc0005/check-vmware
+//
+// Licensed under the MIT License. See LICENSE file in the project root for
+// full license information.
+
+package vsphere
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/atc0005/go-nagios"
+)
+
+// emitSeparator emits a given separator string to the given Writer. If not
+// provided, this function skips emitting any output to the Writer.
+func emitSeparator(w io.Writer, separatorText string) {
+	if separatorText != "" {
+		_, _ = fmt.Fprintf(
+			w,
+			"%s%s%s%s",
+			nagios.CheckOutputEOL,
+			separatorText,
+			nagios.CheckOutputEOL,
+			nagios.CheckOutputEOL,
+		)
+	}
+}

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -697,7 +697,7 @@ func VirtualHardwareReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	_, _ = fmt.Fprintf(

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -1019,13 +1019,7 @@ func H2D2VMsReport(
 
 	}
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	switch {
 	case ignoreMissingCA:
@@ -1104,12 +1098,14 @@ func H2D2VMsReport(
 		)
 	}
 
+	// We skip emitting the separator between the helper function output and
+	// this function's output because we inserted our own earlier.
 	vmFilterResultsReportTrailer(
 		&report,
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		false,
+		skipEmittingSeparator,
 	)
 
 	_, _ = fmt.Fprintf(

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -610,13 +610,7 @@ func HostSystemMemoryUsageReport(
 		)
 	}
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,
@@ -827,13 +821,7 @@ func HostSystemCPUUsageReport(
 		)
 	}
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -807,13 +807,7 @@ func ResourcePoolsMemoryReport(
 
 	}
 
-	_, _ = fmt.Fprintf(
-		&report,
-		"%s---%s%s",
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-		nagios.CheckOutputEOL,
-	)
+	emitSeparator(&report, environmentMetadataHeader)
 
 	_, _ = fmt.Fprintf(
 		&report,

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1656,7 +1656,7 @@ func SnapshotsAgeReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -1700,7 +1700,7 @@ func SnapshotsSizeReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -1745,7 +1745,7 @@ func SnapshotsCountReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()

--- a/internal/vsphere/tools.go
+++ b/internal/vsphere/tools.go
@@ -208,7 +208,7 @@ func VMToolsReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return vmsReport.String()

--- a/internal/vsphere/vcpus.go
+++ b/internal/vsphere/vcpus.go
@@ -199,7 +199,7 @@ func VirtualCPUsReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return vmsReport.String()

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -2652,7 +2652,7 @@ func VMPowerCycleUptimeReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -2755,7 +2755,7 @@ func VMDiskConsolidationReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -2883,7 +2883,7 @@ func VMInteractiveQuestionReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -3145,7 +3145,7 @@ func VMBackupViaCAReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -3294,7 +3294,7 @@ func VMListReport(
 		c,
 		vmsFilterOptions,
 		vmsFilterResults,
-		true,
+		environmentMetadataHeader,
 	)
 
 	return report.String()
@@ -3364,7 +3364,7 @@ func vmFilterResultsReportTrailer(
 	c *vim25.Client,
 	vmsFilterOptions VMsFilterOptions,
 	vmsFilterResults VMsFilterResults,
-	emitSeparator bool,
+	separatorText string,
 ) {
 
 	funcTimeStart := time.Now()
@@ -3376,19 +3376,11 @@ func vmFilterResultsReportTrailer(
 		)
 	}()
 
-	if emitSeparator {
-		_, _ = fmt.Fprintf(
-			w,
-			"%s---%s%s",
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-			nagios.CheckOutputEOL,
-		)
-	}
+	emitSeparator(w, separatorText)
 
 	_, _ = fmt.Fprintf(
 		w,
-		"* vSphere environment: %s%s",
+		"* vSphere endpoint: %s%s",
 		c.URL().String(),
 		nagios.CheckOutputEOL,
 	)


### PR DESCRIPTION
## Changes

Add section header to explicitly separate the list of items from environment info/metadata. This helps resolve formatting issues for notifications sent to Microsoft Teams by way of the send2teams CLI app.

Related changes:

- add new `emitSeparator` helper function
- rework `vmFilterResultsReportTrailer` helper function to accept an optional custom section header or separator vs a boolean to toggle a hardcoded `---` value on/off
- add related constants
  - to provide a consistent section metadata section header where appropriate
  - to provide an explicit empty string to indicate no separator or header is desired
- update consumers of `vmFilterResultsReportTrailer` helper function and similar helper functions to use new `emitSeparator` helper function instead of duplicating logic to provide consistent output across project plugins

## References

- GH-1498