### PR TITLE
go.mod: update minimum Go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@
 
 module github.com/atc0005/check-vmware
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/atc0005/go-nagios v0.20.0


### PR DESCRIPTION
## Overview

The Go project now unconditionally updates the minimum Go version for golang.org/x/ dependencies to be at least 1.(N-1).0, where Go 1.N is the most recent major Go release, and Go 1.(N-1) is the previous major Go release.

Since this project uses dependencies associated with golang.org/x repositories this project's go.mod file is also updated to reflect the new minimum Go version.

## Changes

1. `go get go@1.24.0`
2. `go mod tidy`
3. `go mod vendor`
4. `go fix ./...`
5. `go mod edit -toolchain=none`