### PR TITLE
Apply staticcheck quickfix QF1001, QF1002, QF1008

### DIFF
--- a/cmd/check_vmware_host_cpu/main.go
+++ b/cmd/check_vmware_host_cpu/main.go
@@ -213,8 +213,8 @@ func main() {
 	var numVMsPoweredOn int
 	var numVMsPoweredOff int
 	for _, vm := range hsVMs {
-		switch {
-		case vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn:
+		switch vm.Runtime.PowerState {
+		case types.VirtualMachinePowerStatePoweredOn:
 			numVMsPoweredOn++
 		default:
 			numVMsPoweredOff++

--- a/cmd/check_vmware_host_memory/main.go
+++ b/cmd/check_vmware_host_memory/main.go
@@ -214,8 +214,8 @@ func main() {
 	var numVMsPoweredOn int
 	var numVMsPoweredOff int
 	for _, vm := range hsVMs {
-		switch {
-		case vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn:
+		switch vm.Runtime.PowerState {
+		case types.VirtualMachinePowerStatePoweredOn:
 			numVMsPoweredOn++
 		default:
 			numVMsPoweredOff++

--- a/internal/vsphere/alarms.go
+++ b/internal/vsphere/alarms.go
@@ -800,10 +800,8 @@ func GetTriggeredAlarms(ctx context.Context, c *govmomi.Client, datacenters []mo
 			}
 
 			resourcePoolNames := make([]string, 0, 2)
-			switch {
-			case entity.Self.Type == MgObjRefTypeResourcePool ||
-				entity.Self.Type == MgObjRefTypeVirtualApp ||
-				entity.Self.Type == MgObjRefTypeVirtualMachine:
+			switch entity.Self.Type {
+			case MgObjRefTypeResourcePool, MgObjRefTypeVirtualApp, MgObjRefTypeVirtualMachine:
 
 				rps, err := getResourcePools(ctx, c, entity.Self, propsSubset)
 				if err != nil {
@@ -1759,8 +1757,8 @@ func AlarmsReport(
 
 	numTriggeredAlarmsToReport := len(triggeredAlarms) - triggeredAlarms.NumExcluded()
 
-	switch {
-	case numTriggeredAlarmsToReport == 0:
+	switch numTriggeredAlarmsToReport {
+	case 0:
 		_, _ = fmt.Fprintf(
 			&report,
 			"* None%s%s",
@@ -1844,7 +1842,7 @@ func AlarmsReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 

--- a/internal/vsphere/datacenters.go
+++ b/internal/vsphere/datacenters.go
@@ -134,8 +134,8 @@ func GetDatacenters(ctx context.Context, c *vim25.Client, dcNames []string, prop
 		)
 	}(&filteredDCs)
 
-	switch {
-	case dcNames == nil:
+	switch dcNames {
+	case nil:
 		logger.Println("empty datacenters list provided")
 	default:
 		logger.Println("one or more datacenters specified")

--- a/internal/vsphere/datastores.go
+++ b/internal/vsphere/datastores.go
@@ -311,8 +311,8 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 		_, _ = fmt.Fprintf(w, nagios.CheckOutputEOL)
 	}
 
-	switch {
-	case powerState == types.VirtualMachinePowerStatePoweredOn:
+	switch powerState {
+	case types.VirtualMachinePowerStatePoweredOn:
 		_, _ = fmt.Fprint(
 			w,
 			sectionHeader(
@@ -323,7 +323,7 @@ func printVMSummary(w io.Writer, dsVMs DatastoreVMs, powerState types.VirtualMac
 
 		listVMs(w, dsVMs.VMsPoweredOn())
 
-	case powerState == types.VirtualMachinePowerStatePoweredOff:
+	case types.VirtualMachinePowerStatePoweredOff:
 		_, _ = fmt.Fprint(
 			w,
 			sectionHeader(
@@ -1379,7 +1379,7 @@ func DatastoreSpaceUsageReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
@@ -1641,7 +1641,7 @@ func DatastorePerformanceReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 

--- a/internal/vsphere/get.go
+++ b/internal/vsphere/get.go
@@ -323,8 +323,8 @@ func getObjectByName(ctx context.Context, c *vim25.Client, dst interface{}, objN
 
 	finder := find.NewFinder(c, true)
 
-	switch {
-	case datacenter == "":
+	switch datacenter {
+	case "":
 		dc, findDCErr := finder.DefaultDatacenter(ctx)
 		if findDCErr != nil {
 			return fmt.Errorf("%s: %w", dcNotProvidedFailedToFallback, findDCErr)
@@ -496,8 +496,8 @@ func getResourcePools(ctx context.Context, c *govmomi.Client, moRef types.Manage
 		)
 	}(&resourcePools)
 
-	switch {
-	case moRef.Type == MgObjRefTypeResourcePool:
+	switch moRef.Type {
+	case MgObjRefTypeResourcePool:
 
 		// if the associated entity is a Resource Pool, then its name
 		// and the name of its parent (another Resource Pool) should
@@ -533,7 +533,7 @@ func getResourcePools(ctx context.Context, c *govmomi.Client, moRef types.Manage
 
 		return resourcePools, nil
 
-	case moRef.Type == MgObjRefTypeVirtualMachine:
+	case MgObjRefTypeVirtualMachine:
 		var vm mo.VirtualMachine
 		var rp mo.ResourcePool
 		var vmProps []string

--- a/internal/vsphere/hardware.go
+++ b/internal/vsphere/hardware.go
@@ -102,8 +102,8 @@ func DefaultHardwareVersion(
 
 	finder := find.NewFinder(c, true)
 
-	switch {
-	case datacenterName == "":
+	switch datacenterName {
+	case "":
 		dc, findDCErr := finder.DefaultDatacenter(ctx)
 		if findDCErr != nil {
 			return HardwareVersion{},
@@ -121,8 +121,8 @@ func DefaultHardwareVersion(
 	}
 
 	var computeResourceRef types.ManagedObjectReference
-	switch {
-	case clusterName == "":
+	switch clusterName {
+	case "":
 		cr, findCRErr := finder.DefaultComputeResource(ctx)
 		if findCRErr != nil {
 			return HardwareVersion{},

--- a/internal/vsphere/host-to-datastores.go
+++ b/internal/vsphere/host-to-datastores.go
@@ -251,7 +251,7 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 		case errors.Is(err, ErrCustomAttributeNotSet):
 			logger.Printf(
 				"custom attributes missing for %s %q",
-				host.ManagedEntity.Self.Type,
+				host.Self.Type,
 				host.Name,
 			)
 
@@ -260,7 +260,7 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 		case err != nil:
 			logger.Printf(
 				"failed to retrieve custom attribute for %s %q: %s",
-				host.ManagedEntity.Self.Type,
+				host.Self.Type,
 				host.Name,
 				err,
 			)
@@ -269,7 +269,7 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 			// report them immediately.
 			return nil, fmt.Errorf(
 				"failed to retrieve custom attribute for %s %q: %w",
-				host.ManagedEntity.Self.Type,
+				host.Self.Type,
 				host.Name,
 				err,
 			)
@@ -277,7 +277,7 @@ func GetHostsWithCA(allHosts []mo.HostSystem, hostCustomAttributeName string, ig
 		default:
 			logger.Printf(
 				"successfully retrieved custom attribute for %s %q",
-				host.ManagedEntity.Self.Type,
+				host.Self.Type,
 				host.Name,
 			)
 
@@ -374,7 +374,7 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 		case errors.Is(err, ErrCustomAttributeNotSet):
 			logger.Printf(
 				"custom attributes missing for %s %q",
-				ds.ManagedEntity.Self.Type,
+				ds.Self.Type,
 				ds.Name,
 			)
 
@@ -383,7 +383,7 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 		case err != nil:
 			logger.Printf(
 				"failed to retrieve custom attribute for %s %q: %s",
-				ds.ManagedEntity.Self.Type,
+				ds.Self.Type,
 				ds.Name,
 				err,
 			)
@@ -392,7 +392,7 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 			// report them immediately.
 			return nil, fmt.Errorf(
 				"failed to retrieve custom attribute for %s %q: %w",
-				ds.ManagedEntity.Self.Type,
+				ds.Self.Type,
 				ds.Name,
 				err,
 			)
@@ -400,7 +400,7 @@ func GetDatastoresWithCA(allDS []mo.Datastore, ignoredDatastoreNames []string, d
 		default:
 			logger.Printf(
 				"successfully retrieved custom attribute for %s %q",
-				ds.ManagedEntity.Self.Type,
+				ds.Self.Type,
 				ds.Name,
 			)
 

--- a/internal/vsphere/hosts.go
+++ b/internal/vsphere/hosts.go
@@ -498,8 +498,8 @@ func HostSystemMemoryUsageReport(
 		// vm.Summary.QuickStats.HostMemoryUsage == memory usage in MB
 		vmsMemUsedBytes += int64(vm.Summary.QuickStats.HostMemoryUsage) * units.MB
 
-		switch {
-		case vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn:
+		switch vm.Runtime.PowerState {
+		case types.VirtualMachinePowerStatePoweredOn:
 			vmsPoweredOn++
 		default:
 			vmsPoweredOff++
@@ -622,7 +622,7 @@ func HostSystemMemoryUsageReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 
@@ -709,8 +709,8 @@ func HostSystemCPUUsageReport(
 		vmsCPUUsage += vmCPUUsage
 		logger.Printf("VM %s used %s \n", vm.Name, CPUSpeed(vmCPUUsage))
 
-		switch {
-		case vm.Runtime.PowerState == types.VirtualMachinePowerStatePoweredOn:
+		switch vm.Runtime.PowerState {
+		case types.VirtualMachinePowerStatePoweredOn:
 			vmsPoweredOn++
 		default:
 			vmsPoweredOff++
@@ -833,7 +833,7 @@ func HostSystemCPUUsageReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 

--- a/internal/vsphere/login.go
+++ b/internal/vsphere/login.go
@@ -59,7 +59,7 @@ func Login(
 	}
 
 	// Override default user agent
-	c.Client.UserAgent = userAgent
+	c.UserAgent = userAgent
 
 	// provide credentials *after* we create the client so that the desired
 	// User Agent value can be set before logging in.

--- a/internal/vsphere/resource-pools.go
+++ b/internal/vsphere/resource-pools.go
@@ -675,8 +675,8 @@ func ResourcePoolsMemoryReport(
 		rpIDtoNameIdx[rp.Self.Value] = rp.Name
 
 		rpSummary := rp.Summary.GetResourcePoolSummary()
-		switch {
-		case rpSummary == nil:
+		switch rpSummary {
+		case nil:
 			_, _ = fmt.Fprintf(
 				&report,
 				"* %s [Pool: (unavailable), Cluster: (unavailable)]%s",
@@ -722,8 +722,8 @@ func ResourcePoolsMemoryReport(
 		nagios.CheckOutputEOL,
 	)
 
-	switch {
-	case numVMsPoweredOn == 0:
+	switch numVMsPoweredOn {
+	case 0:
 		_, _ = fmt.Fprintf(
 			&report,
 			"* None (visible); %d powered off%s",
@@ -819,7 +819,7 @@ func ResourcePoolsMemoryReport(
 	_, _ = fmt.Fprintf(
 		&report,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 

--- a/internal/vsphere/snapshots.go
+++ b/internal/vsphere/snapshots.go
@@ -1075,9 +1075,9 @@ func NewSnapshotSummarySet(
 
 			// Conditionally prune disk files not directly associated with the
 			// unique snapshot tree we are evaluating
-			switch {
+			switch parent {
 
-			case parent == nil:
+			case nil:
 
 				// No parent snapshot is present. Remove all attached disk
 				// file keys from the list of snapshot file keys. This leaves
@@ -1455,8 +1455,8 @@ func writeSnapshotsListEntries(
 		// Remove any provided whitespace, append one leading and trailing
 		// space if a subject was provided.
 		forWhat = strings.TrimSpace(forWhat)
-		switch {
-		case forWhat == "":
+		switch forWhat {
+		case "":
 			forWhat = " "
 		default:
 			forWhat = " " + forWhat + " "
@@ -1492,12 +1492,12 @@ func writeSnapshotsListEntries(
 
 	}
 
-	switch {
-	case unitName == snapshotThresholdTypeAge:
+	switch unitName {
+	case snapshotThresholdTypeAge:
 		printSnapshotHeader("", true)
-	case unitName == snapshotThresholdTypeCount:
+	case snapshotThresholdTypeCount:
 		printSnapshotHeader("for VMs", true)
-	case unitName == snapshotThresholdTypeSize:
+	case snapshotThresholdTypeSize:
 		printSnapshotHeader("", true)
 	}
 
@@ -1575,12 +1575,12 @@ func writeSnapshotsListEntries(
 		_, _ = fmt.Fprintln(w, "* None detected")
 	}
 
-	switch {
-	case unitName == snapshotThresholdTypeAge:
+	switch unitName {
+	case snapshotThresholdTypeAge:
 		printSnapshotHeader("", false)
-	case unitName == snapshotThresholdTypeCount:
+	case snapshotThresholdTypeCount:
 		printSnapshotHeader("for VMs", false)
-	case unitName == snapshotThresholdTypeSize:
+	case snapshotThresholdTypeSize:
 		printSnapshotHeader("", false)
 	}
 
@@ -1591,8 +1591,7 @@ func writeSnapshotsListEntries(
 
 		for _, snapSet := range snapshotSummarySets {
 			for _, snap := range snapSet.Snapshots {
-				if !(snap.IsAgeCriticalState() ||
-					snap.IsAgeWarningState()) {
+				if !snap.IsAgeCriticalState() && !snap.IsAgeWarningState() {
 					_, _ = fmt.Fprintf(
 						w,
 						listEntryTemplate,
@@ -1611,7 +1610,7 @@ func writeSnapshotsListEntries(
 		snapshotSummarySets.HasNotYetExceededCount(snapshotWarningThreshold):
 
 		for _, snapSet := range snapshotSummarySets {
-			if !(snapSet.IsCountCriticalState() || snapSet.IsCountWarningState()) {
+			if !snapSet.IsCountCriticalState() && !snapSet.IsCountWarningState() {
 				for _, snap := range snapSet.Snapshots {
 					_, _ = fmt.Fprintf(
 						w,
@@ -1631,8 +1630,7 @@ func writeSnapshotsListEntries(
 		snapshotSummarySets.HasNotYetExceededSize(snapshotWarningThreshold):
 
 		for _, snapSet := range snapshotSummarySets {
-			if !(snapSet.IsSizeWarningState() ||
-				snapSet.IsSizeCriticalState()) {
+			if !snapSet.IsSizeWarningState() && !snapSet.IsSizeCriticalState() {
 				for _, snap := range snapSet.Snapshots {
 					_, _ = fmt.Fprintf(
 						w,

--- a/internal/vsphere/vms.go
+++ b/internal/vsphere/vms.go
@@ -339,8 +339,8 @@ func (vmwb VMWithBackup) HasOldBackup() bool {
 // date. If a backup is not recorded, this is indicated instead of a formatted
 // age.
 func (vmwb VMWithBackup) FormattedBackupAge() string {
-	switch {
-	case vmwb.BackupDate == nil:
+	switch vmwb.BackupDate {
+	case nil:
 		return "Backup unavailable"
 	default:
 		return FormattedTimeSinceEvent(*vmwb.BackupDate)
@@ -350,8 +350,8 @@ func (vmwb VMWithBackup) FormattedBackupAge() string {
 // BackupDaysAgo returns the age of a Virtual Machine's backup date in days.
 // If a backup date is not available, 0 is returned.
 func (vmwb VMWithBackup) BackupDaysAgo() int {
-	switch {
-	case vmwb.BackupDate == nil:
+	switch vmwb.BackupDate {
+	case nil:
 		return 0
 	default:
 		return DaysAgo(*vmwb.BackupDate)
@@ -1484,7 +1484,7 @@ func GetVMsWithCA(vms []mo.VirtualMachine, vmCustomAttributeName string, ignoreM
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to retrieve custom attribute for %s %s: %w",
-				vm.ManagedEntity.Self.Type,
+				vm.Self.Type,
 				vm.Name,
 				err,
 			)
@@ -1543,7 +1543,7 @@ func GetVMsWithCAs(vms []mo.VirtualMachine) ([]VMWithCAs, error) {
 		case err != nil:
 			return nil, fmt.Errorf(
 				"failed to retrieve custom attribute for %s %s: %w",
-				vm.ManagedEntity.Self.Type,
+				vm.Self.Type,
 				vm.Name,
 				err,
 			)
@@ -2858,7 +2858,7 @@ func VMInteractiveQuestionReport(
 				// ))
 				possibleAnswers = append(possibleAnswers, fmt.Sprintf(
 					"'%s'",
-					ed.Description.Label,
+					ed.Label,
 				))
 			}
 
@@ -3388,7 +3388,7 @@ func vmFilterResultsReportTrailer(
 	_, _ = fmt.Fprintf(
 		w,
 		"* Plugin User Agent: %s%s",
-		c.Client.UserAgent,
+		c.UserAgent,
 		nagios.CheckOutputEOL,
 	)
 


### PR DESCRIPTION
The following quickfix automatic refactorings have been applied to simplify existing code:

- `QF1001: could apply De Morgan's law`
- `QF1002: could use tagged switch on ...`
- `QF1008: could remove embedded field ... from selector`

These refactorings were applied via:

```
golangci-lint-v2 run \
    --no-config \
    --enable-only=staticcheck \
    --fix \
    ./...
```

golangci-lint v2.11.1 was used to apply these changes.